### PR TITLE
Adds short expiration to login cookie

### DIFF
--- a/app/scripts/stores/mainStore.js
+++ b/app/scripts/stores/mainStore.js
@@ -93,8 +93,9 @@ var MainStore = Reflux.createStore({
     },
 
     isLoggedInHandler() {
+        let expiresAt = new Date(Date.now() + (60 * 1000));
         this.appConfig.isLoggedIn = true;
-        cookie.save('isLoggedIn', this.appConfig.isLoggedIn);
+        cookie.save('isLoggedIn', this.appConfig.isLoggedIn, {expires: expiresAt});
         this.modalOpen = MainStore.modalOpen;
         this.trigger({
             appConfig: this.appConfig,


### PR DESCRIPTION
I found that although I have a method to clear this cookie out when the home component mounts, occasionally it wasn't being cleared (maybe 1 out of 10 logins or so). I think this is occasionally causing a redirect loop on the login page. I added a one minute expiration to this cookie so that if it isn't cleared on mount it will expire in one minute anyways. 
