### PR TITLE
Credentials button in software agents now returns all credentials

### DIFF
--- a/app/scripts/components/globalComponents/agentList.jsx
+++ b/app/scripts/components/globalComponents/agentList.jsx
@@ -21,26 +21,28 @@ class AgentList extends React.Component {
         let agentKey = this.props.agentKey ? this.props.agentKey.key : null;
         let userKey = this.props.userKey ? this.props.userKey.key : null;
         let apiToken = this.props.agentApiToken ? this.props.agentApiToken.api_token : null;
+        let obj = {agent_key: agentKey, user_key: userKey, api_token: apiToken};
         let open = this.props.modal ? this.props.modal : false;
         let msg = Object.keys(ProjectStore.agentApiToken).length === 0 ?
             <h6 style={styles.apiMsg}>You must have a valid user key, please create one by selecting 'USER SECRET KEY' in the drop down menu.</h6> :
-            <h6 style={styles.apiMsg2}>This API token will expire in 2 hours.</h6>;
+            <h6 style={styles.apiMsg2}>The API token included with these credentials will expire in 2 hours.</h6>;
 
         let keyActions = [
             <FlatButton
-                label="OKAY"
+                label="CANCEL"
                 secondary={true}
                 keyboardFocused={true}
                 onTouchTap={() => this.handleClose()} />,
             <FlatButton
-                label="COPY API TOKEN TO CLIPBOARD"
+                label="COPY CREDENTIALS TO CLIPBOARD"
                 secondary={true}
                 onTouchTap={this.copyApiKey.bind(this)} />
         ];
 
         let modal = <Dialog
             style={styles.dialogStyles}
-            title="API Token"
+            title="Agent Credentials"
+            contentStyle={styles.dialogPosition}
             autoDetectWindowHeight={true}
             autoScrollBodyContent={true}
             actions={keyActions}
@@ -50,7 +52,7 @@ class AgentList extends React.Component {
             <form action="#" id="apiKeyForm" className="keyText">
                 <TextField
                     style={styles.keyModal}
-                    defaultValue={apiToken}
+                    defaultValue={JSON.stringify(obj, null, 4)}
                     floatingLabelText="Api Token"
                     id="keyText"
                     type="text"
@@ -126,14 +128,27 @@ class AgentList extends React.Component {
             let formData = new FormData();
             formData.append('agent_key', agentKey);
             formData.append('user_key', userKey);
-            if (!userKey || !agentKey){
-                ProjectActions.openModal();
+            if (!userKey){
+                ProjectActions.createUserKey();
+                ProjectActions.getUserKey();
+                setTimeout(() => {
+                    let agentKey = this.props.agentKey ? this.props.agentKey.key : null;
+                    let userKey = this.props.userKey ? this.props.userKey.key : null;
+                    let formData = new FormData();
+                    formData.append('agent_key', agentKey);
+                    formData.append('user_key', userKey);
+                    if (!userKey){
+                        ProjectActions.createUserKey();
+                        ProjectActions.getUserKey();
+
+                    } else {
+                        ProjectActions.getAgentApiToken(agentKey, userKey, formData);
+                    }
+                }, 800);
             } else {
                 ProjectActions.getAgentApiToken(agentKey, userKey, formData);
             }
         }, 800);
-
-
     }
 
     copyApiKey() {
@@ -175,6 +190,12 @@ var styles = {
         fontColor: '#303F9F',
         zIndex: '5000'
     },
+    dialogPosition: {
+        position: 'absolute',
+        left: '50%',
+        top: '50%',
+        transform: 'translate(-50%, -50%)'
+    },
     dlIcon: {
         float: 'right',
         fontSize: 18,
@@ -205,7 +226,8 @@ var styles = {
     keyModal: {
         width: 300,
         textAlign: 'left',
-        fontFamily: 'monospace'
+        fontFamily: 'monospace',
+        fontSize: '1em'
     },
     list: {
         float: 'right',


### PR DESCRIPTION
Changed credentials button in software agents list to return all credentials in JSON format rather than returning the api token only
