### PR TITLE
Changed input hint text to not show on mobile

### DIFF
--- a/app/scripts/actions/projectActions.js
+++ b/app/scripts/actions/projectActions.js
@@ -8,6 +8,7 @@ import { StatusEnum, Path } from '../enum';
 import { checkStatus, getAuthenticatedFetchParams } from '../../util/fetchUtil.js';
 
 var ProjectActions = Reflux.createActions([
+    'getDeviceType',
     'hashFile',
     'postHash',
     'openModal',

--- a/app/scripts/components/globalComponents/search.jsx
+++ b/app/scripts/components/globalComponents/search.jsx
@@ -50,7 +50,7 @@ class Search extends React.Component {
     }
 
     render() {
-        let projectName = ProjectStore.project && ProjectStore.project.name ? 'in '+ProjectStore.project.name : '';
+        let projectName = ProjectStore.project && ProjectStore.project.name && window.innerWidth > 580 ? 'in '+ProjectStore.project.name : '';
         let route = this.props.routerPath.split('/').splice([1], 1).toString();
         let cancelSearch = this.state.clear ?
             <IconButton onTouchTap={() => this.clearSearch(route)} className="searchbar-cancel"

--- a/app/scripts/pages/app.jsx
+++ b/app/scripts/pages/app.jsx
@@ -27,10 +27,7 @@ class App extends React.Component {
     constructor(props) {
         super(props);
         this.state = {
-            appConfig: MainStore.appConfig,
-            clear: false,
-            searchInput: 'search',
-            timeout: null
+            appConfig: MainStore.appConfig
         };
     }
 
@@ -43,7 +40,14 @@ class App extends React.Component {
     componentDidMount() {
         this.unsubscribe = MainStore.listen(state => this.setState(state));
         this.showToasts();
+        let app = new Framework7();
         new Framework7().addView('.view-main', {dynamicNavbar: true});
+        let device = {
+            android: app.device.android,
+            ipad: app.device.ipad,
+            iphone: app.device.iphone
+        };
+        ProjectActions.getDeviceType(device)
     }
 
     componentWillUnmount() {

--- a/app/scripts/stores/projectStore.js
+++ b/app/scripts/stores/projectStore.js
@@ -15,6 +15,7 @@ var ProjectStore = Reflux.createStore({
         this.currentUser = {};
         this.destination = null;
         this.destinationKind = null;
+        this.device = {};
         this.entityObj = null;
         this.error = {};
         this.errorModal = false;
@@ -38,6 +39,13 @@ var ProjectStore = Reflux.createStore({
         this.users = [];
         this.userKey = {};
         this.versionModal = false;
+    },
+
+    getDeviceType(device) {
+        this.device = device;
+        this.trigger({
+            device: this.device
+        })
     },
 
     setSearchText(text) {


### PR DESCRIPTION
Text is too big for a mobile screen. Set the hint text to default to "Search" if on a screen smaller than 580px wide
