### PR TITLE
Added assetPath to DDS_PORTAL_CONFIG in index.ejs as a test

### DIFF
--- a/app/index.ejs
+++ b/app/index.ejs
@@ -30,7 +30,7 @@
         var rString = randomString(32, '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ');
         var DDS_PORTAL_CONFIG = {
             serviceId: '<%= env.SERVICE_ID -%>',
-            assetPath: '<%= @asset_path -%>',
+            assetPath: 'https://dev.dataservice.duke.edu/'
             baseUrl: '<%= env.DDS_API_URL -%>',
             authServiceUri: '<%= env.AUTH_SERVICE_BASE_URI -%>',
             authServiceName: '<%= env.AUTH_SERVICE_NAME -%>',


### PR DESCRIPTION
Note: When using these techniques to inline your worker code, importScripts() will only work if you supply an absolute URI. If you attempt to pass a relative URI, the browser will complain with a security error. The reason being: the worker (now created from a blob URL) will be resolved with a blob: prefix, while your app will be running from a different (presumably http://) scheme. Hence, the failure will be due to cross origin restrictions.

One way to utilize importScripts() in an inline worker is to "inject" the current url of your main script is running from by passing it to the inline worker and constructing the absolute URL manually. This will insure the external script is imported from the same origin. Assuming your main app is running from http://example.com/index.html:
