### PR TITLE
Metadata feature small fixes

### DIFF
--- a/app/scripts/actions/projectActions.js
+++ b/app/scripts/actions/projectActions.js
@@ -8,6 +8,7 @@ import { StatusEnum } from '../enum';
 import { checkStatus, getFetchParams } from '../../util/fetchUtil';
 
 var ProjectActions = Reflux.createActions([
+    'createMetaPropsList',
     'getObjectMetadata',
     'getObjectMetadataSuccess',
     'createMetadataObject',

--- a/app/scripts/components/fileComponents/customMetadata.jsx
+++ b/app/scripts/components/fileComponents/customMetadata.jsx
@@ -1,15 +1,11 @@
 import React, { PropTypes } from 'react';
 const { object, bool, array, string } = PropTypes;
-import ProjectActions from '../../actions/projectActions';
 import ProjectStore from '../../stores/projectStore';
-import BaseUtils from '../../../util/baseUtils.js';
 import Card from 'material-ui/lib/card/card';
 
-class CustomMetadata extends React.Component {
-
-    render() {
+const CustomMetadata = () => {
         let metadataItems = [];
-        metadataItems = this.props.objectMetadata && this.props.objectMetadata !== null ? this.props.objectMetadata.map((obj)=>{
+        metadataItems = ProjectStore.objectMetadata && ProjectStore.objectMetadata !== null ? ProjectStore.objectMetadata.map((obj)=>{
            let properties = obj.properties.map((prop)=>{
                return <span key={prop.template_property.id}>
                     <li className="list-group-title">{prop.template_property.key}</li>
@@ -42,8 +38,7 @@ class CustomMetadata extends React.Component {
                 {customMetadata}
             </div>
         )
-    }
-}
+};
 
 var styles = {
     card: {
@@ -63,7 +58,7 @@ CustomMetadata.contextTypes = {
 };
 
 CustomMetadata.propTypes = {
-    error: object
+    objectMetadata: React.PropTypes.array
 };
 
 export default CustomMetadata;

--- a/app/scripts/components/fileComponents/fileDetails.jsx
+++ b/app/scripts/components/fileComponents/fileDetails.jsx
@@ -47,7 +47,7 @@ class FileDetails extends React.Component {
         let label = this.props.entityObj && this.props.entityObj.current_version.label ? this.props.entityObj.current_version.label : null;
         let projectName = this.props.entityObj && this.props.entityObj.ancestors ? this.props.entityObj.ancestors[0].name : null;
         let crdOn = this.props.entityObj && this.props.entityObj.audit ? this.props.entityObj.audit.created_on : null;
-        let x = new Date(crdOn);
+        let x = crdOn !== null ? new Date(crdOn) : '';
         let createdOn = x.toString();
         let createdBy = this.props.entityObj && this.props.entityObj.audit ? this.props.entityObj.audit.created_by.full_name : null;
         let lastUpdatedOn = this.props.entityObj && this.props.entityObj.audit ? this.props.entityObj.audit.last_updated_on : null;
@@ -183,7 +183,7 @@ class FileDetails extends React.Component {
                                 <li className="list-group-title">Size</li>
                                 <li className="item-content">
                                     <div className="item-inner">
-                                        <div>{ BaseUtils.bytesToSize(bytes) }</div>
+                                        <div>{ bytes !== null ? BaseUtils.bytesToSize(bytes) : '' }</div>
                                     </div>
                                 </li>
                             </ul>

--- a/app/scripts/components/fileComponents/versionDetails.jsx
+++ b/app/scripts/components/fileComponents/versionDetails.jsx
@@ -39,7 +39,7 @@ class VersionDetails extends React.Component {
         let label = this.props.entityObj && this.props.entityObj.label ? this.props.entityObj.label : null;
         let projectName = this.props.entityObj && this.props.entityObj.ancestors ? this.props.entityObj.ancestors[0].name : null;
         let crdOn = this.props.entityObj && this.props.entityObj.audit ? this.props.entityObj.audit.created_on : null;
-        let x = new Date(crdOn);
+        let x = crdOn !== null ? new Date(crdOn) : '';
         let createdOn = x.toString();
         let createdBy = this.props.entityObj && this.props.entityObj.audit ? this.props.entityObj.audit.created_by.full_name : null;
         let lastUpdatedOn = this.props.entityObj && this.props.entityObj.audit ? this.props.entityObj.audit.last_updated_on : null;
@@ -103,7 +103,7 @@ class VersionDetails extends React.Component {
                                 <li className="list-group-title">Size</li>
                                 <li className="item-content">
                                     <div className="item-inner">
-                                        <div>{ BaseUtils.bytesToSize(bytes) }</div>
+                                        <div>{ bytes !== null ? BaseUtils.bytesToSize(bytes) : '' }</div>
                                     </div>
                                 </li>
                             </ul>

--- a/app/scripts/components/globalComponents/metadataObjectCreator.jsx
+++ b/app/scripts/components/globalComponents/metadataObjectCreator.jsx
@@ -149,20 +149,36 @@ class MetadataObjectCreator extends React.Component {
         )
     }
 
+    replacePropertyValue(metaProps, id, value) {
+        metaProps = metaProps.filter(( obj ) => {
+            return obj.key !== id;
+        });
+        metaProps.push({key: id, value: value});
+        this.setState({metaProps: metaProps});
+    }
+
     addDateProperty(x, date, id) { // x is event which is always null. This is MUI behavior
+        let metaProps = this.state.metaProps;
         if(!BaseUtils.objectPropInArray(this.state.metaProps, 'key', id)) { //If not in array, add object
-            let metaProps = this.state.metaProps;
             metaProps.push({key: id, value: date});
             this.setState({metaProps: metaProps});
+        } else {
+            if(BaseUtils.objectPropInArray(this.state.metaProps, 'key', id)) { //If in array, value changed, replace obj
+                this.replacePropertyValue(metaProps, id, date);
+            }
         }
     }
 
-    addToPropertyList(id, type) {
+    addToPropertyList(id) {
+        let value = this.refs[id].getValue();
+        let metaProps = this.state.metaProps;
         if(this.refs[id].getValue() !== '' && !BaseUtils.objectPropInArray(this.state.metaProps, 'key', id)) {
-            let value = this.refs[id].getValue();
-            let metaProps = this.state.metaProps;
             metaProps.push({key: id, value: value});
             this.setState({metaProps: metaProps});
+        } else {
+            if(BaseUtils.objectPropInArray(this.state.metaProps, 'key', id)) {
+                this.replacePropertyValue(metaProps, id, value);
+            }
         }
     }
 

--- a/app/scripts/components/globalComponents/metadataObjectCreator.jsx
+++ b/app/scripts/components/globalComponents/metadataObjectCreator.jsx
@@ -154,16 +154,16 @@ class MetadataObjectCreator extends React.Component {
             return obj.key !== id;
         });
         metaProps.push({key: id, value: value});
-        this.setState({metaProps: metaProps});
+        ProjectActions.createMetaPropsList(metaProps);
     }
 
     addDateProperty(x, date, id) { // x is event which is always null. This is MUI behavior
-        let metaProps = this.state.metaProps;
-        if(!BaseUtils.objectPropInArray(this.state.metaProps, 'key', id)) { //If not in array, add object
+        let metaProps = ProjectStore.metaProps;
+        if(!BaseUtils.objectPropInArray(metaProps, 'key', id)) { //If not in array, add object
             metaProps.push({key: id, value: date});
-            this.setState({metaProps: metaProps});
+            ProjectActions.createMetaPropsList(metaProps);
         } else {
-            if(BaseUtils.objectPropInArray(this.state.metaProps, 'key', id)) { //If in array, value changed, replace obj
+            if(BaseUtils.objectPropInArray(metaProps, 'key', id)) { //If in array, value changed, replace obj
                 this.replacePropertyValue(metaProps, id, date);
             }
         }
@@ -171,12 +171,12 @@ class MetadataObjectCreator extends React.Component {
 
     addToPropertyList(id) {
         let value = this.refs[id].getValue();
-        let metaProps = this.state.metaProps;
-        if(this.refs[id].getValue() !== '' && !BaseUtils.objectPropInArray(this.state.metaProps, 'key', id)) {
+        let metaProps = ProjectStore.metaProps;
+        if(this.refs[id].getValue() !== '' && !BaseUtils.objectPropInArray(metaProps, 'key', id)) {
             metaProps.push({key: id, value: value});
-            this.setState({metaProps: metaProps});
+            ProjectActions.createMetaPropsList(metaProps);
         } else {
-            if(BaseUtils.objectPropInArray(this.state.metaProps, 'key', id)) {
+            if(BaseUtils.objectPropInArray(metaProps, 'key', id)) {
                 this.replacePropertyValue(metaProps, id, value);
             }
         }
@@ -186,17 +186,17 @@ class MetadataObjectCreator extends React.Component {
         let kind = 'dds-file';
         let files = this.props.filesChecked;
         let fileId = this.props.params.id;
-        let properties = this.state.metaProps;
+        let metaProps = ProjectStore.metaProps;
         let errors = this.state.errorText;
         if(Object.keys(errors).length === 0 && errors.constructor === Object) {
-            if(properties.length) {
+            if(metaProps.length) {
                 if (this.props.filesChecked.length > 0) {
                     for (let i = 0; i < files.length; i++) {
-                        ProjectActions.createMetadataObject(kind, files[i], templateId, properties);
+                        ProjectActions.createMetadataObject(kind, files[i], templateId, metaProps);
                         if(!!document.getElementById(files[i])) document.getElementById(files[i]).checked = false;
                     }
                 } else {
-                    ProjectActions.createMetadataObject(kind, fileId, templateId, properties);
+                    ProjectActions.createMetadataObject(kind, fileId, templateId, metaProps);
                 }
                 this.toggleTagManager();
             } else {
@@ -225,18 +225,18 @@ class MetadataObjectCreator extends React.Component {
         if(!pass && type === 'text') this.state.errorText[id] = {type: type, text: 'must contain text'};
         this.setState({ errorText: this.state.errorText, noValueWarning: false});
         if(value === '') { // If value is deleted then remove property from metaProps
-            let properties = this.state.metaProps;
-            properties = properties.filter((obj) => {
+            let metaProps = ProjectStore.metaProps;
+            metaProps = metaProps.filter((obj) => {
                 return obj.key !== id;
             });
-            this.setState({metaProps: properties});
+            ProjectActions.createMetaPropsList(metaProps);
         }
     }
 
     toggleTagManager() {
         ProjectActions.toggleTagManager();
+        ProjectActions.createMetaPropsList([]);
         if(this.props.showTemplateDetails) ProjectActions.showMetadataTemplateList();
-        this.setState({tagsToAdd: [], metaProps: []});
     }
 }
 
@@ -357,6 +357,7 @@ MetadataObjectCreator.propTypes = {
     currentUser: React.PropTypes.object,
     entityObj: React.PropTypes.object,
     filesChecked: React.PropTypes.array,
+    metaProps: React.PropTypes.array,
     metaTemplates: React.PropTypes.array,
     metadataTemplate: React.PropTypes.object
 };

--- a/app/scripts/components/globalComponents/metadataTemplateList.jsx
+++ b/app/scripts/components/globalComponents/metadataTemplateList.jsx
@@ -5,6 +5,7 @@ import MainActions from '../../actions/mainActions';
 import ProjectActions from '../../actions/projectActions';
 import ProjectStore from '../../stores/projectStore';
 import AddAgentModal from '../../components/globalComponents/addAgentModal.jsx';
+import CircularProgress from 'material-ui/lib/circular-progress';
 import Dialog from 'material-ui/lib/dialog';
 import FlatButton from 'material-ui/lib/flat-button';
 import Help from 'material-ui/lib/svg-icons/action/help';
@@ -104,11 +105,11 @@ class MetadataTemplateList extends React.Component {
                         {!this.state.searchMode ?
                             <IconButton
                                 tooltip="Search Templates"
-                                style={styles.searchIcon} onTouchTap={()=>this.toggleSearch()}>
+                                style={styles.searchIcon} onTouchTap={()=>this.toggleSearch(false)}>
                             <Search />
                         </IconButton> :
                         <IconButton
-                            style={styles.searchIcon} onTouchTap={()=>this.toggleSearch()}>
+                            style={styles.searchIcon} onTouchTap={()=>this.toggleSearch(true)}>
                             <Close />
                         </IconButton>}
                         <Toggle
@@ -138,6 +139,7 @@ class MetadataTemplateList extends React.Component {
                 </div>
                 <div className="mdl-cell mdl-cell--12-col" style={styles.loading}>
                     {this.props.uploads || this.props.loading && route === 'metadata' ? <Loaders {...this.props}/> : null}
+                    {this.props.uploads || this.props.loading && route !== 'metadata' ? <CircularProgress size={1.5} style={styles.drawerLoader}/> : null}
                 </div>
                 <div className="mdl-cell mdl-cell--12-col content-block" style={styles.list}>
                     <div className="list-block media-list">
@@ -173,12 +175,16 @@ class MetadataTemplateList extends React.Component {
         ProjectActions.toggleMetadataManager();
     }
 
-    toggleSearch() {
-        setTimeout(()=> {
-        let searchInput = this.refs.searchInput;
-        searchInput.focus();
-            if (this.state.searchValue !== ('' || 'search')) this.setState({searchValue:''});
-        }, 100);
+    toggleSearch(close) {
+        if(!close) {
+            setTimeout(()=> {
+                let searchInput = this.refs.searchInput;
+                searchInput.focus();
+                if (this.state.searchValue !== ('' || 'search')) this.setState({searchValue: ''});
+            }, 100);
+        } else {
+            ProjectActions.loadMetadataTemplates(null);
+        }
         this.setState({searchMode: !this.state.searchMode});
     }
 
@@ -206,6 +212,13 @@ var styles = {
         label: {
             fontWeight: 100
         }
+    },
+    drawerLoader: {
+        position: 'absolute',
+        margin: '0 auto',
+        top: 200,
+        left: 0,
+        right: 0
     },
     headerTitle: {
         float: 'left',

--- a/app/scripts/stores/projectStore.js
+++ b/app/scripts/stores/projectStore.js
@@ -246,9 +246,11 @@ var ProjectStore = Reflux.createStore({
     },
 
     loadMetadataTemplates() {
+        if(this.metaTemplates.length) this.metaTemplates = [];
         this.loading = true;
         this.trigger({
-            loading: this.loading
+            loading: this.loading,
+            metaTemplates: this.metaTemplates
         })
     },
 

--- a/app/scripts/stores/projectStore.js
+++ b/app/scripts/stores/projectStore.js
@@ -38,6 +38,7 @@ var ProjectStore = Reflux.createStore({
         this.drawerLoading = false;
         this.itemsSelected = null;
         this.metaDataTemplate = null;
+        this.metaProps = [];
         this.metaTemplates = [];
         this.modal = false;
         this.moveModal = false;
@@ -91,6 +92,13 @@ var ProjectStore = Reflux.createStore({
         this.objectMetadata = results;
         this.trigger({
             objectMetadata: this.objectMetadata
+        })
+    },
+
+    createMetaPropsList(metaProps) {
+        this.metaProps = metaProps;
+        this.trigger({
+            metaProps: this.metaProps
         })
     },
 

--- a/app/util/baseUtils.js
+++ b/app/util/baseUtils.js
@@ -69,7 +69,7 @@ let BaseUtils = {
                     return /^[-+]?[0-9]+\.[0-9]+$/.test(v);
                     break;
                 case 'boolean':
-                    return /^(true|false|1|0)$/.test(v);
+                    return /^(true|false|1|0)$/i.test(v);
                     break;
                 case 'text':
                     return true;


### PR DESCRIPTION
- Fixes loader in the metadata template list when it is in the right hand drawer (metadata object creation)

- Reloads all templates after the user exits the template search bar

- Fixed validation of boolean property type to be case insensitive. Accepts "true", "True" etc. as well as "0" or "1"