### PR TITLE
Format date for metadata properties to yyyy-mm-dd

### DIFF
--- a/app/scripts/components/fileComponents/customMetadata.jsx
+++ b/app/scripts/components/fileComponents/customMetadata.jsx
@@ -33,7 +33,7 @@ const CustomMetadata = () => {
                 </div>
         </Card>;
         return (
-            <div>
+            <div className="project-container">
                 <h5 className="mdl-color-text--grey-800" style={styles.heading}>Custom Metadata</h5>
                 {customMetadata}
             </div>
@@ -45,8 +45,9 @@ var styles = {
         padding: '10px 0px 10px 0px'
     },
     heading: {
-        paddingLeft: 10
-    },
+        paddingLeft: 0,
+        marginTop: 15
+},
     list: {
         paddingTop: 5,
         clear: 'both'

--- a/app/scripts/components/globalComponents/metadataObjectCreator.jsx
+++ b/app/scripts/components/globalComponents/metadataObjectCreator.jsx
@@ -159,12 +159,13 @@ class MetadataObjectCreator extends React.Component {
 
     addDateProperty(x, date, id) { // x is event which is always null. This is MUI behavior
         let metaProps = ProjectStore.metaProps;
+        let formattedDate = date.toISOString().split('T')[0];
         if(!BaseUtils.objectPropInArray(metaProps, 'key', id)) { //If not in array, add object
-            metaProps.push({key: id, value: date});
+            metaProps.push({key: id, value: formattedDate});
             ProjectActions.createMetaPropsList(metaProps);
         } else {
             if(BaseUtils.objectPropInArray(metaProps, 'key', id)) { //If in array, value changed, replace obj
-                this.replacePropertyValue(metaProps, id, date);
+                this.replacePropertyValue(metaProps, id, formattedDate);
             }
         }
     }


### PR DESCRIPTION
-Fixes breaking change from new date format validation on the api. Formats date to `yyyy-mm-dd` and removes the trailing `[THH:mm[:ss]]` because this isn't set by the datepicker in the UI anyways. 