### PR TITLE
Adds heroku-ssl-redirect and helmet.js

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,8 +1,10 @@
+var hsts = require('hsts');
+var sslRedirect = require('heroku-ssl-redirect');
 var express = require('express');
-
 var app = express();
+
 app.set('port', (process.env.PORT || 5000));
-app.use(express.static(__dirname + '/dist'));
+app.use(sslRedirect(['development','ua_test','production']), hsts({maxAge: 15552000}), express.static(__dirname + '/dist'));
 
 app.set('views', __dirname + '/dist');
 app.set('view engine', 'ejs');

--- a/package.json
+++ b/package.json
@@ -48,6 +48,8 @@
     "gulp-util": "^3.0.4",
     "gulp-watch": "^4.2.1",
     "gulp-webpack": "^1.5.0",
+    "helmet": "^3.4.0",
+    "heroku-ssl-redirect": "0.0.3",
     "history": "^3.0.0",
     "material-ui": "^0.16.7",
     "react": "^15.4.2",


### PR DESCRIPTION
Uses:

For HSTS:  https://github.com/helmetjs/hsts

For HTTPS redirect:  https://github.com/nodenica/node-heroku-ssl-redirect

Notes: HSTS headers aren't supported on IE < 11