### PR TITLE
Extend metadata to activities

### DIFF
--- a/__test__/mainStore.test.js
+++ b/__test__/mainStore.test.js
@@ -25,6 +25,7 @@ describe('Main Store', () => {
     const TEMPLATE_NAME = 'TEMPLATE_1';
     const TEMPLATE_DESCRIPTION = 'TEMPLATE 1 DESCRIPTION';
     const TEMPLATE_LABEL = 'TEMPLATE 1';
+    const TEMPLATE_PROPERTY = 'TEMPLATE PROPERTY 1';
     const TEST_USER_NAME = 'TEST USER NAME';
     const TEST_UID = 'TEST01';
     const USER_ROLE = 'USER_ROLE';
@@ -491,7 +492,7 @@ describe('Main Store', () => {
 
     it('@action createMetadataObjectSuccess - creates a new metadata object for a file', () => {
         mainStore.objectMetadata = [];
-        mainStore.createMetadataObjectSuccess(FILE_ID, DDS_FILE, fake.metadata_object_json);
+        mainStore.createMetadataObjectSuccess(fake.metadata_object_json);
         expect(mainStore.drawerLoading).toBe(false);
         expect(mainStore.showBatchOps).toBe(false);
         expect(mainStore.showTemplateDetails).toBe(false);
@@ -961,8 +962,20 @@ describe('Main Store', () => {
             expect(mainStore.objectMetadata[0].object.kind).toBe(DDS_FILE);
             expect(mainStore.objectMetadata[0].template.id).toBe(TEMPLATE_ID);
             expect(mainStore.objectMetadata[0]).toHaveProperty('properties');
-            expect(mainStore.metaObjProps[0][0].key).toBe('TEST_TEMPLATE_PROPERTY_KEY_1');
-            expect(mainStore.metaObjProps[0][0].value).toBe('TEST_TEMPLATE_PROPERTY_VALUE');
+            expect(mainStore.metaObjProps[0][0].key).toBe('TEMPLATE_PROPERTY_1');
+            expect(mainStore.metaObjProps[0][0].value).toBe(TEMPLATE_PROPERTY);
+        });
+    });
+
+    it('@action deleteObjectMetadata - should delete a metadata object for file', () => {
+        mainStore.objectMetadata = fake.object_metadata_json.results;
+        expect(mainStore.objectMetadata.length).toBe(1);
+        transportLayer.deleteObjectMetadata = jest.fn(() => respondOK());
+        mainStore.deleteObjectMetadata(fake.file_json, fake.object_metadata_json.results[0].template);
+        return sleep(1).then(() => {
+            expect(transportLayer.deleteObjectMetadata).toHaveBeenCalledTimes(1);
+            expect(transportLayer.deleteObjectMetadata).toHaveBeenCalledWith(fake.file_json, fake.object_metadata_json.results[0].template.id);
+            expect(mainStore.objectMetadata.length).toBe(0);
         });
     });
 

--- a/__test__/mainStore.test.js
+++ b/__test__/mainStore.test.js
@@ -962,8 +962,8 @@ describe('Main Store', () => {
             expect(mainStore.objectMetadata[0].object.kind).toBe(DDS_FILE);
             expect(mainStore.objectMetadata[0].template.id).toBe(TEMPLATE_ID);
             expect(mainStore.objectMetadata[0]).toHaveProperty('properties');
-            expect(mainStore.metaObjProps[0][0].key).toBe('TEMPLATE_PROPERTY_1');
-            expect(mainStore.metaObjProps[0][0].value).toBe(TEMPLATE_PROPERTY);
+            expect(mainStore.metaObjProps[0][0].key).toBe('TEST_TEMPLATE_PROPERTY_KEY_1');
+            expect(mainStore.metaObjProps[0][0].value).toBe('TEST_TEMPLATE_PROPERTY_VALUE');
         });
     });
 

--- a/__test__/provenanceStore.test.js
+++ b/__test__/provenanceStore.test.js
@@ -14,9 +14,11 @@ describe('Provenance Store', () => {
 
     let transportLayer = null;
     let provenanceStore = null;
+    let mainStore = null;
 
     beforeEach(() => {
         provenanceStore = require('../app/scripts/stores/provenanceStore').default;
+        mainStore = require('../app/scripts/stores/mainStore').default;
         transportLayer = {};
         provenanceStore.transportLayer = transportLayer;
     });

--- a/__test__/provenanceStore.test.js
+++ b/__test__/provenanceStore.test.js
@@ -199,6 +199,7 @@ describe('Provenance Store', () => {
 
     it('@action addFileToGraph - adds a file to the provenance graph', () => {
         provenanceStore.provNodes = [fake.prov_activity_json];
+        provenanceStore.currentGraph = {};
         expect(provenanceStore.provNodes.length).toBe(1);
         provenanceStore.addFileToGraph(fake.prov_file_node_json);
         expect(provenanceStore.provNodes.length).toBe(2);

--- a/app/scripts/components/fileComponents/customMetadata.jsx
+++ b/app/scripts/components/fileComponents/customMetadata.jsx
@@ -1,26 +1,25 @@
 import React, { PropTypes } from 'react';
-const { object, bool, array, string } = PropTypes;
+const { array } = PropTypes;
 import { observer } from 'mobx-react';
 import mainStore from '../../stores/mainStore';
 import Card from 'material-ui/Card';
 
-
 const CustomMetadata = observer(() => {
     const {objectMetadata} = mainStore;
-    let metadataItems = [];
-    metadataItems = objectMetadata && objectMetadata.length ? objectMetadata.map((obj)=>{
+
+    let metadataItems = objectMetadata && objectMetadata.length ? objectMetadata.map((obj) => {
         let properties = obj.properties.map((prop)=>{
             return <span key={prop.template_property.id}>
-                    <li className="list-group-title">{prop.template_property.key}</li>
                     <li className="item-content">
                         <div className="item-inner">
-                            <div>{prop.value}</div>
+                            <div className="mdl-color-text--grey-600">{prop.template_property.key+' '}<span className="mdl-color-text--grey-800">=></span><span className="mdl-color-text--grey-600">{' '+prop.value}</span></div>
                         </div>
                     </li>
                </span>
         });
         return <span key={obj.template.id}>
-                <div className="list-group">
+                <div className="list-group" style={{listStyle: 'none'}}>
+                    <li className="list-group-title">{obj.template.name}<i className="material-icons" style={{float: 'right', cursor: 'pointer', color: 'red'}}>delete_forever</i></li>
                     <ul>
                         {properties}
                     </ul>

--- a/app/scripts/components/fileComponents/customMetadata.jsx
+++ b/app/scripts/components/fileComponents/customMetadata.jsx
@@ -2,50 +2,77 @@ import React, { PropTypes } from 'react';
 const { array } = PropTypes;
 import { observer } from 'mobx-react';
 import mainStore from '../../stores/mainStore';
+import { Color } from '../../theme/customTheme';
 import Card from 'material-ui/Card';
 
-const CustomMetadata = observer(() => {
-    const {objectMetadata} = mainStore;
+import IconButton from 'material-ui/IconButton';
 
-    let metadataItems = objectMetadata && objectMetadata.length ? objectMetadata.map((obj) => {
-        let properties = obj.properties.map((prop)=>{
-            return <span key={prop.template_property.id}>
-                    <li className="item-content">
-                        <div className="item-inner">
-                            <div className="mdl-color-text--grey-600">{prop.template_property.key+' '}<span className="mdl-color-text--grey-800">=></span><span className="mdl-color-text--grey-600">{' '+prop.value}</span></div>
-                        </div>
-                    </li>
+@observer
+class CustomMetadata extends React.Component {
+
+    render() {
+        const {objectMetadata} = mainStore;
+
+        let metadataItems = objectMetadata && objectMetadata.length ? objectMetadata.map((obj) => {
+            let properties = obj.properties.map((prop)=>{
+                return <span key={prop.template_property.id}>
+                        <li className="item-content">
+                            <div className="item-inner">
+                                <div className="mdl-color-text--grey-600">{prop.template_property.key+' '}<span className="mdl-color-text--grey-800">=></span><span className="mdl-color-text--grey-600">{' '+prop.value}</span></div>
+                            </div>
+                        </li>
+                   </span>
+            });
+            return <span key={obj.template.id}>
+                    <div className="list-group" style={styles.listStyle}>
+                        <li className="list-group-title" style={styles.listItemPadding}>{obj.template.name}
+                            <IconButton
+                                iconClassName="material-icons"
+                                style={styles.deleteIcon}
+                                iconStyle={styles.deleteIcon.iconColor}
+                                onTouchTap={() => this.deleteObjectMetadata(obj.object, obj.template)} >
+                                delete_forever
+                            </IconButton>
+                        </li>
+                        <ul>
+                            {properties}
+                        </ul>
+                    </div>
                </span>
-        });
-        return <span key={obj.template.id}>
-                <div className="list-group" style={{listStyle: 'none'}}>
-                    <li className="list-group-title">{obj.template.name}<i className="material-icons" style={{float: 'right', cursor: 'pointer', color: 'red'}}>delete_forever</i></li>
-                    <ul>
-                        {properties}
-                    </ul>
+        }) : null;
+        let customMetadata = <Card className="project-container mdl-color--white content mdl-color-text--grey-800"
+                                   style={styles.card}>
+            <div className="mdl-cell mdl-cell--12-col content-block" style={styles.list}>
+                <div className="list-block">
+                    {metadataItems}
                 </div>
-           </span>
-    }) : null;
-    let customMetadata = <Card className="project-container mdl-color--white content mdl-color-text--grey-800"
-                               style={styles.card}>
-        <div className="mdl-cell mdl-cell--12-col content-block" style={styles.list}>
-            <div className="list-block">
-                {metadataItems}
             </div>
-        </div>
-    </Card>;
-    return (
-        <div className="project-container" style={styles.wrapper}>
-            <h5 className="mdl-color-text--grey-800" style={styles.heading}>Custom Metadata</h5>
-            {customMetadata}
-        </div>
-    )
-});
+        </Card>;
+        return (
+            <div className="project-container" style={styles.wrapper}>
+                <h5 className="mdl-color-text--grey-800" style={styles.heading}>Custom Metadata</h5>
+                {customMetadata}
+            </div>
+        )
+    }
+
+    deleteObjectMetadata(object, template) {
+        mainStore.deleteObjectMetadata(object, template);
+    };
+
+}
 
 const styles = {
     card: {
         padding: '10px 0px 10px 0px',
         marginTop: 0
+    },
+    deleteIcon: {
+        float: 'right',
+        cursor: 'pointer',
+        iconColor: {
+            color: Color.red
+        }
     },
     heading: {
         paddingLeft: 0,
@@ -54,6 +81,12 @@ const styles = {
     list: {
         paddingTop: 5,
         clear: 'both'
+    },
+    listStyle: {
+        listStyle: 'none'
+    },
+    listItemPadding: {
+        paddingRight: 0
     },
     wrapper: {
         marginTop: 0

--- a/app/scripts/components/fileComponents/fileDetails.jsx
+++ b/app/scripts/components/fileComponents/fileDetails.jsx
@@ -24,7 +24,7 @@ import RaisedButton from 'material-ui/RaisedButton';
 class FileDetails extends React.Component {
 
     render() {
-        const {entityObj, fileVersions, loading, objectMetadata, projPermissions, screenSize, uploads} = mainStore;
+        const {entityObj, fileVersions, loading, objectMetadata, projPermissions, screenSize, showBackButton, uploads} = mainStore;
         const { showProvAlert } = provenanceStore;
         let prjPrm = projPermissions && projPermissions !== null ? projPermissions : null;
         let dlButton = null;
@@ -40,8 +40,6 @@ class FileDetails extends React.Component {
             optionsMenu = <FileOptionsMenu {...this.props} clickHandler={()=>this.setSelectedEntity()}/>;
         }
         let ancestors = entityObj && entityObj.ancestors ? entityObj.ancestors : [];
-        let parentKind = entityObj && entityObj.parent ? entityObj.parent.kind : null;
-        let parentId = entityObj  && entityObj.parent ? entityObj.parent.id : null;
         let name = entityObj ? entityObj.name : '';
         let label = entityObj && entityObj.current_version && entityObj.current_version.label ? entityObj.current_version.label : '';
         let crdOn = entityObj && entityObj.audit ? entityObj.audit.created_on : null;
@@ -92,10 +90,10 @@ class FileDetails extends React.Component {
         let file = <Card className="project-container mdl-color--white content mdl-color-text--grey-800" style={styles.card}>
             <div className="mdl-cell mdl-cell--12-col mdl-color-text--grey-800">
                 <div className="mdl-cell mdl-cell--12-col mdl-color-text--grey-800" style={styles.arrow}>
-                    <a href={'/#/' + BaseUtils.getUrlPath(parentKind) + parentId } style={styles.back} className="mdl-color-text--grey-800 external">
+                    { showBackButton && <a href="#" style={styles.back} className="mdl-color-text--grey-800 external" onTouchTap={() => this.goBack()}>
                         <i className="material-icons" style={styles.backIcon}>keyboard_backspace</i>
                         Back
-                    </a>
+                    </a> }
                     <div style={styles.menuIcon}>
                         { optionsMenu }
                     </div>
@@ -229,6 +227,10 @@ class FileDetails extends React.Component {
 
     dismissAlert(){
         provenanceStore.hideProvAlert();
+    }
+
+    goBack() {
+        this.props.router.goBack();
     }
 
     handleDownload(){

--- a/app/scripts/components/fileComponents/fileDetails.jsx
+++ b/app/scripts/components/fileComponents/fileDetails.jsx
@@ -24,7 +24,7 @@ import RaisedButton from 'material-ui/RaisedButton';
 class FileDetails extends React.Component {
 
     render() {
-        const {entityObj, fileVersions, loading, objectMetadata, projPermissions, screenSize, showBackButton, uploads} = mainStore;
+        const {entityObj, fileVersions, loading, objectMetadata, projPermissions, screenSize, uploads} = mainStore;
         const { showProvAlert } = provenanceStore;
         let prjPrm = projPermissions && projPermissions !== null ? projPermissions : null;
         let dlButton = null;
@@ -36,7 +36,7 @@ class FileDetails extends React.Component {
                                                                                              labelStyle={{color: Color.blue}}
                                                                                              style={styles.dlButton}
                                                                                              icon={<FileDownload color={Color.pink} />}
-                                                                                             onTouchTap={() => this.handleDownload()}/>
+                                                                                             onTouchTap={() => this.handleDownload()}/>;
             optionsMenu = <FileOptionsMenu {...this.props} clickHandler={()=>this.setSelectedEntity()}/>;
         }
         let ancestors = entityObj && entityObj.ancestors ? entityObj.ancestors : [];
@@ -46,6 +46,8 @@ class FileDetails extends React.Component {
         let createdBy = entityObj && entityObj.audit ? entityObj.audit.created_by.full_name : null;
         let lastUpdatedOn = entityObj && entityObj.audit ? entityObj.audit.last_updated_on : null;
         let lastUpdatedBy = entityObj && entityObj.audit.last_updated_by ? entityObj.audit.last_updated_by.full_name : null;
+        let parentKind = entityObj && entityObj.parent ? entityObj.parent.kind : null;
+        let parentId = entityObj  && entityObj.parent ? entityObj.parent.id : null;
         let storage =  entityObj && entityObj.current_version && entityObj.current_version.upload ? entityObj.current_version.upload.storage_provider.description : null;
         let bytes = entityObj && entityObj.current_version && entityObj.current_version.upload ? entityObj.current_version.upload.size : null;
         let hash = entityObj && entityObj.current_version && entityObj.current_version.upload.hashes.length ? entityObj.current_version.upload.hashes[0].algorithm +': '+ entityObj.current_version.upload.hashes[0].value : null;
@@ -90,10 +92,10 @@ class FileDetails extends React.Component {
         let file = <Card className="project-container mdl-color--white content mdl-color-text--grey-800" style={styles.card}>
             <div className="mdl-cell mdl-cell--12-col mdl-color-text--grey-800">
                 <div className="mdl-cell mdl-cell--12-col mdl-color-text--grey-800" style={styles.arrow}>
-                    { showBackButton && <a href="#" style={styles.back} className="mdl-color-text--grey-800 external" onTouchTap={() => this.goBack()}>
+                    <a href={'/#/' + BaseUtils.getUrlPath(parentKind) + parentId } style={styles.back} className="mdl-color-text--grey-800 external" onTouchTap={() => this.goBack()}>
                         <i className="material-icons" style={styles.backIcon}>keyboard_backspace</i>
                         Back
-                    </a> }
+                    </a>
                     <div style={styles.menuIcon}>
                         { optionsMenu }
                     </div>
@@ -230,7 +232,7 @@ class FileDetails extends React.Component {
     }
 
     goBack() {
-        this.props.router.goBack();
+        mainStore.showBackButton ? this.props.router.goBack() : null;
     }
 
     handleDownload(){

--- a/app/scripts/components/fileComponents/fileOptionsMenu.jsx
+++ b/app/scripts/components/fileComponents/fileOptionsMenu.jsx
@@ -77,11 +77,16 @@ class FileOptionsMenu extends React.Component {
     }
 
     toggleProv(id, versionId) {
+        const { currentGraph } = provenanceStore;
         let projId = this.props.router.location.pathname.includes('project') ? this.props.params.id : mainStore.entityObj.ancestors[0].id;
         mainStore.searchFiles('', projId);
-        provenanceStore.getWasGeneratedByNode(versionId);
+        if(currentGraph === null || (currentGraph !== null && currentGraph.id !== this.props.params.id)) {
+            provenanceStore.getWasGeneratedByNode(versionId);
+        } else if (currentGraph !== null && currentGraph.id === this.props.params.id) {
+            provenanceStore.shouldRenderGraph();
+        }
         provenanceStore.toggleProvView();
-        this.props.router.push('/file/'+id);
+        !this.props.router.location.pathname.includes(id) ? this.props.router.push('/file/'+id) : null;
     }
 
     openTagManager(id) {

--- a/app/scripts/components/fileComponents/versionDetails.jsx
+++ b/app/scripts/components/fileComponents/versionDetails.jsx
@@ -15,7 +15,7 @@ import RaisedButton from 'material-ui/RaisedButton';
 class VersionDetails extends React.Component {
 
     render() {
-        const {entityObj, loading, projPermissions, showBackButton} = mainStore;
+        const {entityObj, loading, projPermissions} = mainStore;
         let prjPrm = projPermissions && projPermissions !== null ? projPermissions : null;
         let dlButton = null;
         let optionsMenu = null;
@@ -44,9 +44,9 @@ class VersionDetails extends React.Component {
         let version = <Card className="project-container mdl-color--white content mdl-color-text--grey-800" style={styles.card}>
             <div className="mdl-cell mdl-cell--12-col mdl-color-text--grey-800">
                 <div className="mdl-cell mdl-cell--12-col mdl-color-text--grey-800" style={styles.arrow}>
-                    { showBackButton && <a href="#" style={styles.back} className="mdl-color-text--grey-800 external" onTouchTap={() => this.goBack()}>
+                    <a href={UrlGen.routes.file(parentId)} style={styles.back} className="mdl-color-text--grey-800 external" onTouchTap={() => this.goBack()}>
                         <i className="material-icons" style={styles.backIcon}>keyboard_backspace</i>Back
-                    </a> }
+                    </a>
                     <div style={styles.menuIcon}>
                         { optionsMenu }
                     </div>
@@ -114,8 +114,10 @@ class VersionDetails extends React.Component {
                                 <li className="item-content">
                                     <div className="item-inner">
                                         <a href={UrlGen.routes.file(parentId)} className="external">
-                                            <div style={{color: Color.blue}}>                                             <i className="material-icons" style={styles.linkIcon}>link</i>
-                                                {name} </div>
+                                            <div style={{color: Color.blue}}>
+                                                <i className="material-icons" style={styles.linkIcon}>link</i>
+                                                {name}
+                                            </div>
                                         </a>
                                     </div>
                                 </li>
@@ -174,7 +176,7 @@ class VersionDetails extends React.Component {
     }
 
     goBack() {
-        this.props.router.goBack();
+        mainStore.showBackButton ? this.props.router.goBack() : null;
     }
 
     handleDownload(){

--- a/app/scripts/components/fileComponents/versionDetails.jsx
+++ b/app/scripts/components/fileComponents/versionDetails.jsx
@@ -15,7 +15,7 @@ import RaisedButton from 'material-ui/RaisedButton';
 class VersionDetails extends React.Component {
 
     render() {
-        const {entityObj, loading, projPermissions} = mainStore;
+        const {entityObj, loading, projPermissions, showBackButton} = mainStore;
         let prjPrm = projPermissions && projPermissions !== null ? projPermissions : null;
         let dlButton = null;
         let optionsMenu = null;
@@ -44,10 +44,9 @@ class VersionDetails extends React.Component {
         let version = <Card className="project-container mdl-color--white content mdl-color-text--grey-800" style={styles.card}>
             <div className="mdl-cell mdl-cell--12-col mdl-color-text--grey-800">
                 <div className="mdl-cell mdl-cell--12-col mdl-color-text--grey-800" style={styles.arrow}>
-                    <a href={UrlGen.routes.file(parentId)} style={styles.back}
-                       className="mdl-color-text--grey-800 external">
-                        <i className="material-icons"
-                           style={styles.backIcon}>keyboard_backspace</i>Back</a>
+                    { showBackButton && <a href="#" style={styles.back} className="mdl-color-text--grey-800 external" onTouchTap={() => this.goBack()}>
+                        <i className="material-icons" style={styles.backIcon}>keyboard_backspace</i>Back
+                    </a> }
                     <div style={styles.menuIcon}>
                         { optionsMenu }
                     </div>
@@ -172,6 +171,10 @@ class VersionDetails extends React.Component {
                 <Loaders {...this.props}/>
             </div>
         )
+    }
+
+    goBack() {
+        this.props.router.goBack();
     }
 
     handleDownload(){

--- a/app/scripts/components/folderComponents/folderPath.jsx
+++ b/app/scripts/components/folderComponents/folderPath.jsx
@@ -14,7 +14,7 @@ import FontIcon from 'material-ui/FontIcon';
 class FolderPath extends React.Component {
     
     render() {
-        const {entityObj, projPermissions} = mainStore;
+        const {entityObj, projPermissions, showBackButton} = mainStore;
         let ancestors = entityObj ? entityObj.ancestors : null;
         let parentKind = entityObj ? entityObj.parent.kind : null;
         let parentId = entityObj ? entityObj.parent.id : null;
@@ -33,10 +33,10 @@ class FolderPath extends React.Component {
                 { uploadMdl }
                 <div className="mdl-cell mdl-cell--12-col mdl-color-text--grey-800">
                     <div className="mdl-cell mdl-cell--12-col mdl-color-text--grey-800" style={styles.arrow}>
-                        <a href={'/#/' + BaseUtils.getUrlPath(parentKind) + parentId } className="mdl-color-text--grey-800 external">
+                        { showBackButton && <a href="#" className="mdl-color-text--grey-800 external" onTouchTap={() => this.goBack()}>
                             <i className="material-icons" style={styles.backIcon}>keyboard_backspace</i>
                             Back
-                        </a>
+                        </a> }
                         <div style={styles.menuIcon}>
                             { optionsMenu }
                         </div>
@@ -51,6 +51,10 @@ class FolderPath extends React.Component {
                 </div>
             </Card>
         );
+    }
+
+    goBack() {
+        this.props.router.goBack();
     }
 
     setSelectedEntity() {

--- a/app/scripts/components/folderComponents/folderPath.jsx
+++ b/app/scripts/components/folderComponents/folderPath.jsx
@@ -14,7 +14,7 @@ import FontIcon from 'material-ui/FontIcon';
 class FolderPath extends React.Component {
     
     render() {
-        const {entityObj, projPermissions, showBackButton} = mainStore;
+        const {entityObj, projPermissions} = mainStore;
         let ancestors = entityObj ? entityObj.ancestors : null;
         let parentKind = entityObj ? entityObj.parent.kind : null;
         let parentId = entityObj ? entityObj.parent.id : null;
@@ -33,10 +33,10 @@ class FolderPath extends React.Component {
                 { uploadMdl }
                 <div className="mdl-cell mdl-cell--12-col mdl-color-text--grey-800">
                     <div className="mdl-cell mdl-cell--12-col mdl-color-text--grey-800" style={styles.arrow}>
-                        { showBackButton && <a href="#" className="mdl-color-text--grey-800 external" onTouchTap={() => this.goBack()}>
+                        <a href={'/#/' + BaseUtils.getUrlPath(parentKind) + parentId } className="mdl-color-text--grey-800 external" onTouchTap={() => this.goBack()}>
                             <i className="material-icons" style={styles.backIcon}>keyboard_backspace</i>
                             Back
-                        </a> }
+                        </a>
                         <div style={styles.menuIcon}>
                             { optionsMenu }
                         </div>
@@ -54,7 +54,7 @@ class FolderPath extends React.Component {
     }
 
     goBack() {
-        this.props.router.goBack();
+        mainStore.showBackButton ? this.props.router.goBack() : null;
     }
 
     setSelectedEntity() {

--- a/app/scripts/components/globalComponents/activityDetails.jsx
+++ b/app/scripts/components/globalComponents/activityDetails.jsx
@@ -1,0 +1,174 @@
+import React, { PropTypes } from 'react';
+const { object, bool } = PropTypes;
+import { observer } from 'mobx-react';
+import mainStore from '../../stores/mainStore';
+import provenanceStore from '../../stores/provenanceStore';
+import ActivityOptionsMenu from './activityOptionsMenu.jsx';
+import CustomMetadata from '../fileComponents/customMetadata.jsx';
+import Loaders from './loaders.jsx';
+import TagCloud from './tagCloud.jsx';
+import BaseUtils from '../../util/baseUtils.js';
+import Card from 'material-ui/Card';
+import FontIcon from 'material-ui/FontIcon';
+
+@observer
+class ActivityDetails extends React.Component {
+
+    render() {
+        const { activity } = provenanceStore;
+        const { screenSize, showBackButton, uploads, loading, objectMetadata } = mainStore;
+        const width = screenSize !== null && Object.keys(screenSize).length !== 0 ? screenSize.width : window.innerWidth;
+
+        const activityDetails = activity !== null && <Card className="project-container mdl-color--white content mdl-color-text--grey-800" style={styles.card}>
+                <div className="mdl-cell mdl-cell--12-col mdl-color-text--grey-800">
+                    <div className="mdl-cell mdl-cell--12-col mdl-color-text--grey-800" style={styles.arrow}>
+                        { showBackButton && <a href="#" style={styles.back} className="mdl-color-text--grey-800 external" onTouchTap={() => this.goBack()}>
+                            <i className="material-icons" style={styles.backIcon}>keyboard_backspace</i>Back
+                        </a> }
+                        <div style={styles.menuIcon}>
+                            <ActivityOptionsMenu {...this.props}/>
+                        </div>
+                    </div>
+                    <div className="mdl-cell mdl-cell--12-col mdl-cell--8-col-tablet mdl-cell--4-col-phone" style={styles.detailsTitle}>
+                        <span className="mdl-color-text--grey-800" style={styles.title}><FontIcon className="material-icons" style={styles.icon}>class</FontIcon>{ activity.name }</span>
+                    </div>
+                    <div className="mdl-cell mdl-cell--12-col mdl-cell--8-col-tablet mdl-color-text--grey-800" style={styles.subTitle}>
+                        <span style={styles.spanTitle}>{ activity.description }</span>
+                    </div>
+                    {width >  300 ? <TagCloud {...this.props}/> : null}
+                    <div>
+                        { uploads || loading ? <Loaders {...this.props}/> : null }
+                    </div>
+                    <div className="mdl-cell mdl-cell--12-col content-block" style={styles.list}>
+                        <div className="list-block">
+                            <div className="list-group">
+                                <ul>
+                                    <li className="list-group-title">Activity Started On</li>
+                                    <li className="item-content">
+                                        <div className="item-inner">
+                                            <div>{ BaseUtils.formatDate(activity.started_on) }</div>
+                                        </div>
+                                    </li>
+                                </ul>
+                            </div>
+                            <div className="list-group">
+                                <ul>
+                                    <li className="list-group-title">Activity Ended On</li>
+                                    <li className="item-content">
+                                        <div className="item-inner">
+                                            <div>{ activity.ended_on === null ? 'N/A' : BaseUtils.formatDate(activity.ended_on) }</div>
+                                        </div>
+                                    </li>
+                                </ul>
+                            </div>
+                            <div className="list-group">
+                                <ul>
+                                    <li className="list-group-title">Last Updated By</li>
+                                    <li className="item-content">
+                                        <div className="item-inner">
+                                            <div>{ activity.audit.last_updated_by === null ? 'N/A' : activity.audit.last_updated_by.full_name}</div>
+                                        </div>
+                                    </li>
+                                </ul>
+                            </div>
+                            <div className="list-group">
+                                <ul>
+                                    <li className="list-group-title">Last Updated On</li>
+                                    <li className="item-content">
+                                        <div className="item-inner">
+                                            <div>{ activity.audit.last_updated_on === null ? 'N/A' : BaseUtils.formatDate(activity.audit.last_updated_on) }</div>
+                                        </div>
+                                    </li>
+                                </ul>
+                            </div>
+                            <div className="list-group">
+                                <ul>
+                                    <li className="list-group-title">Activity ID</li>
+                                    <li className="item-content">
+                                        <div className="item-inner">
+                                            <div>{ activity.id }</div>
+                                        </div>
+                                    </li>
+                                </ul>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </Card>;
+
+        return (
+            <div>
+                {activityDetails}
+                {objectMetadata && objectMetadata.length ? <CustomMetadata {...this.props}/> : null}
+            </div>
+        )
+    }
+
+    goBack() {
+        this.props.router.goBack();
+        !provenanceStore.toggleProv && provenanceStore.currentGraph !== null ? provenanceStore.toggleProvView() : null;
+        provenanceStore.currentGraph !== null ? provenanceStore.shouldRenderGraph() : null;
+    }
+
+}
+
+const styles = {
+    arrow: {
+        textAlign: 'left',
+        marginTop: -5
+    },
+    backIcon: {
+        fontSize: 24,
+        verticalAlign:-7
+    },
+    back: {
+        verticalAlign:-7
+    },
+    card: {
+        paddingBottom: 30,
+        overflow: 'visible',
+        padding: '10px 0px 10px 0px'
+    },
+    detailsTitle: {
+        textAlign: 'left',
+        float: 'left',
+        margin: '10px 0px 10px 20px'
+    },
+    icon: {
+        fontSize: 28,
+        verticalAlign: 'bottom'
+    },
+    list: {
+        paddingTop: 5,
+        clear: 'both'
+    },
+    menuIcon: {
+        float: 'right',
+        marginTop: -6,
+        marginRight: -6
+    },
+    subTitle: {
+        textAlign: 'left',
+        float: 'left',
+        margin: '10px 0px 20px 25px'
+    },
+    spanTitle: {
+        fontSize: '1.2em'
+    },
+    title: {
+        fontSize: 24,
+        wordWrap: 'break-word'
+    }
+};
+
+ActivityDetails.contextTypes = {
+    muiTheme: React.PropTypes.object
+};
+
+ActivityDetails.propTypes = {
+    loading: bool,
+    activity: object,
+    screenSize: object
+};
+
+export default ActivityDetails;

--- a/app/scripts/components/globalComponents/activityOptionsMenu.jsx
+++ b/app/scripts/components/globalComponents/activityOptionsMenu.jsx
@@ -1,0 +1,177 @@
+import React, { PropTypes } from 'react';
+const { object, bool } = PropTypes;
+import { observer } from 'mobx-react';
+import mainStore from '../../stores/mainStore';
+import provenanceStore from '../../stores/provenanceStore';
+import TextField from 'material-ui/TextField';
+import Dialog from 'material-ui/Dialog';
+import FlatButton from 'material-ui/FlatButton';
+import IconButton from 'material-ui/IconButton';
+import IconMenu from 'material-ui/IconMenu';
+import MenuItem from 'material-ui/MenuItem';
+
+@observer
+class ActivityOptionsMenu extends React.Component {
+
+    constructor(props) {
+        super(props);
+        this.state = {
+            deleteOpen: false,
+            editOpen: false,
+            floatingErrorText: '',
+            floatingErrorText2: ''
+        }
+    }
+
+    render() {
+        const { screenSize, toggleModal } = mainStore;
+        const { activity } = provenanceStore;
+        const dialogWidth = screenSize.width < 580 ? {width: '100%'} : {};
+        const id = activity !== null ? activity.id : null;
+        const name = activity !== null ? activity.name : null;
+        const description = activity !== null ? activity.description : null;
+        const menu = <IconMenu
+                    iconButtonElement={<IconButton iconClassName="material-icons" style={{marginRight: -10}}>more_vert</IconButton>}
+                    anchorOrigin={{horizontal: 'right', vertical: 'top'}}
+                    targetOrigin={{horizontal: 'right', vertical: 'top'}}>
+                    <MenuItem primaryText="Delete Activity" leftIcon={<i className="material-icons">delete</i>}
+                              onTouchTap={() => this.toggleModal('dltActivity')}/>
+                    <MenuItem primaryText="Edit Activity Details"
+                              leftIcon={<i className="material-icons">mode_edit</i>}
+                              onTouchTap={() => this.toggleModal('editActivity')}/>
+                </IconMenu>;
+
+        const deleteActions = [
+            <FlatButton
+                label="CANCEL"
+                secondary={true}
+                onTouchTap={() => this.toggleModal('dltActivity')}/>,
+            <FlatButton
+                label="DELETE"
+                secondary={true}
+                keyboardFocused={true}
+                onTouchTap={() => this.handleDeleteButton(id, name)}/>
+        ];
+
+        const editActions = [
+            <FlatButton
+                label="CANCEL"
+                secondary={true}
+                onTouchTap={() => this.toggleModal('editActivity')}/>,
+            <FlatButton
+                label="UPDATE"
+                secondary={true}
+                keyboardFocused={true}
+                onTouchTap={() => this.handleUpdateButton(id)}/>
+        ];
+
+        return (
+            <div>
+                <Dialog
+                    style={styles.dialogStyles}
+                    contentStyle={dialogWidth}
+                    title="Are you sure you want to delete this activity?"
+                    autoDetectWindowHeight={true}
+                    actions={deleteActions}
+                    onRequestClose={() => this.toggleModal('dltActivity')}
+                    open={toggleModal && toggleModal.id === 'dltActivity' ? toggleModal.open : false}>
+                    <i className="material-icons" style={styles.warning}>warning</i>
+                </Dialog>
+                <Dialog
+                    style={styles.dialogStyles}
+                    contentStyle={dialogWidth}
+                    title="Edit Activity Details"
+                    autoDetectWindowHeight={true}
+                    actions={editActions}
+                    onRequestClose={() => this.toggleModal('editActivity')}
+                    open={toggleModal && toggleModal.id === 'editActivity' ? toggleModal.open : false}>
+                    <form action="#" id="editActivityForm">
+                        <TextField
+                            style={styles.textStyles}
+                            autoFocus={true}
+                            onFocus={()=>this.selectText()}
+                            hintText="Activity Name"
+                            defaultValue={name}
+                            errorText={this.state.floatingErrorText}
+                            ref={(input) => this.nameInput = input}
+                            floatingLabelText="Activity Name"
+                            type="text"
+                            multiLine={true}
+                            onChange={(e)=>this.validateText(e)}/> <br/>
+                        <TextField
+                            style={styles.textStyles}
+                            hintText="Activity Description"
+                            defaultValue={description}
+                            errorText={this.state.floatingErrorText2}
+                            ref={(input) => this.descriptionInput = input}
+                            floatingLabelText="Activity Description"
+                            type="text"
+                            multiLine={true}
+                            onChange={(e)=>this.validateText(e)}/>
+                    </form>
+                </Dialog>
+                { menu }
+            </div>
+        );
+    }
+
+    handleDeleteButton(id, name) {
+        provenanceStore.deleteProvActivity(id, name);
+        this.toggleModal('dltActivity');
+        this.props.router.goBack();
+    }
+
+
+    handleUpdateButton(id) {
+        const prevName = provenanceStore.activity.name;
+        const name = this.nameInput.getValue();
+        const description = this.descriptionInput.getValue();
+        if (this.state.floatingErrorText2 !== '' && this.state.floatingErrorText !== '') {
+            return null
+        } else {
+            provenanceStore.editProvActivity(id, name, description, prevName);
+            this.toggleModal('editActivity');
+        }
+    }
+
+    selectText() {
+        setTimeout(()=>this.nameInput.select(),100);
+    }
+
+    validateText(e) {
+        const name = this.nameInput.getValue();
+        const description = this.descriptionInput.getValue();
+        this.setState({
+            floatingErrorText: name.length ? '' : 'This field is required.',
+            floatingErrorText2: description.length ? '' : 'This field is required.'
+        });
+    }
+
+    toggleModal(id) {
+        mainStore.toggleModals(id)
+    }
+}
+const styles = {
+    dialogStyles: {
+        textAlign: 'center',
+        fontColor: '#303F9F',
+        zIndex: '9999'
+    },
+    textStyles: {
+        textAlign: 'left',
+        fontColor: '#303F9F'
+    },
+    warning: {
+        fontSize: 48,
+        textAlign: 'center',
+        color: '#F44336'
+    }
+};
+
+ActivityOptionsMenu.propTypes = {
+    activity: object,
+    toggleModal: object,
+    screenSize: object
+};
+
+export default ActivityOptionsMenu;

--- a/app/scripts/components/globalComponents/dropzone.jsx
+++ b/app/scripts/components/globalComponents/dropzone.jsx
@@ -30,7 +30,7 @@ class DropZone extends React.Component {
     }
 
     render() {
-        let dropzoneColor = this.state.dropzoneHover ? '#EEE' : '#FFF';
+        let dropzoneColor = this.state.dropzoneHover ? '#C8E6C9' : '#F5F5F5';
 
         return (
             <form action="/" className="dropzone needsclick dz-clickable" id="dropArea">

--- a/app/scripts/components/globalComponents/listItems.jsx
+++ b/app/scripts/components/globalComponents/listItems.jsx
@@ -21,12 +21,9 @@ import {Table, TableBody, TableHeader, TableHeaderColumn, TableRow, TableRowColu
 class ListItems extends React.Component {
 
     render() {
-        const { allItemsSelected, filesChecked, foldersChecked, isSafari, listItems, loading, projPermissions, responseHeaders, screenSize, tableBodyRenderKey, uploads } = mainStore;
+        const { allItemsSelected, filesChecked, foldersChecked, isSafari, listItems, loading, nextPage, projPermissions, screenSize, tableBodyRenderKey, totalItems, uploads } = mainStore;
         let showBatchOps = !!(filesChecked.length || foldersChecked.length);
         let menuWidth = screenSize.width > 1230 ? 35 : 28;
-        let headers = responseHeaders && responseHeaders !== null ? responseHeaders : null;
-        let nextPage = headers !== null && !!headers['x-next-page'] ? headers['x-next-page'][0] : null;
-        let totalChildren = headers !== null && !!headers['x-total'] ? headers['x-total'][0] : null;
         let newFolderModal = null;
         let uploadManager = null;
         let showChecks = null;
@@ -109,7 +106,7 @@ class ListItems extends React.Component {
                             {children}
                         </TableBody>
                     </Table>}
-                    {listItems.length < totalChildren && totalChildren > 25 &&
+                    {listItems.length < totalItems && totalItems > 25 &&
                     <div className="mdl-cell mdl-cell--12-col">
                         <RaisedButton
                             label={loading ? "Loading..." : "Load More"}

--- a/app/scripts/components/globalComponents/metadataObjectCreator.jsx
+++ b/app/scripts/components/globalComponents/metadataObjectCreator.jsx
@@ -2,6 +2,7 @@ import React, { PropTypes } from 'react';
 const { object, array } = PropTypes;
 import { observer } from 'mobx-react';
 import mainStore from '../../stores/mainStore';
+import provenanceStore from '../../stores/provenanceStore';
 import BaseUtils from '../../util/baseUtils';
 import { Kind } from '../../util/urlEnum';
 import { Color } from '../../theme/customTheme';
@@ -24,6 +25,8 @@ class MetadataObjectCreator extends React.Component {
 
     render() {
         const { entityObj, filesChecked, metaObjProps, metadataTemplate, templateProperties } = mainStore;
+        const { selectedNode } = provenanceStore;
+
         function formatDate(date) {
             return (date.getMonth() + 1) + "/" + date.getDate() + "/" + date.getFullYear();
         }
@@ -43,7 +46,7 @@ class MetadataObjectCreator extends React.Component {
             );
         }
 
-        let name = entityObj && filesChecked < 1 ? entityObj.name : 'selected files';
+        let name = entityObj && filesChecked < 1 ? selectedNode && selectedNode.properties !== undefined ? selectedNode.properties.name : entityObj.name : 'selected files';
         let metaObjProperties = metaObjProps && metaObjProps !== null ? metaObjProps : null;
         let properties = templateProperties && templateProperties.length !== 0 ? templateProperties.map((obj)=>{
             let type = BaseUtils.getTemplatePropertyType(obj.type);
@@ -202,8 +205,11 @@ class MetadataObjectCreator extends React.Component {
     }
 
     createMetadataObject(templateId) {
+        const { selectedNode } = provenanceStore;
+        const { selectedEntity } = mainStore;
         let files = mainStore.filesChecked;
-        let fileId = mainStore.selectedEntity !== null ? mainStore.selectedEntity.id : this.props.params.id;
+        let id = selectedNode && selectedNode.properties !== undefined ? selectedNode.properties.id : selectedEntity !== null ? selectedEntity.id : this.props.params.id;
+        const kind = selectedNode && selectedNode.properties !== undefined && selectedNode.properties.kind === Kind.DDS_ACTIVITY ? Kind.DDS_ACTIVITY : Kind.DDS_FILE;
         let metaProps = mainStore.metaProps.slice();
         let errors = this.state.errorText;
         if(Object.keys(errors).length === 0 && errors.constructor === Object) {
@@ -213,7 +219,7 @@ class MetadataObjectCreator extends React.Component {
                         mainStore.createMetadataObject(Kind.DDS_FILE, files[i], templateId, metaProps);
                     }
                 } else {
-                    mainStore.createMetadataObject(Kind.DDS_FILE, fileId, templateId, metaProps);
+                    mainStore.createMetadataObject(kind, id, templateId, metaProps);
                 }
                 this.toggleTagManager();
             } else {

--- a/app/scripts/components/globalComponents/metadataObjectCreator.jsx
+++ b/app/scripts/components/globalComponents/metadataObjectCreator.jsx
@@ -54,11 +54,11 @@ class MetadataObjectCreator extends React.Component {
                         if(p.id === obj.id && obj.type !== 'date') {
                             value = p.value;
                         } else if(p.id === obj.id && obj.type === 'date') {
-                            value = new Date(p.value.split("-").join("/"))
+                            value = new Date(p.value.split("-").join("/"));
                         }
                     });
                 });
-                return value;
+                if(value !== '') return value;
             };
             return (
                 <TableRow  key={obj.id}>
@@ -185,6 +185,7 @@ class MetadataObjectCreator extends React.Component {
                 this.replacePropertyValue(metaProps, key, formattedDate);
             }
         }
+        if(this.state.noValueWarning) this.setState({noValueWarning: false})
     }
 
     addToPropertyList(key) {

--- a/app/scripts/components/globalComponents/metadataObjectCreator.jsx
+++ b/app/scripts/components/globalComponents/metadataObjectCreator.jsx
@@ -209,7 +209,7 @@ class MetadataObjectCreator extends React.Component {
         const { selectedEntity } = mainStore;
         let files = mainStore.filesChecked;
         let id = selectedNode && selectedNode.properties !== undefined ? selectedNode.properties.id : selectedEntity !== null ? selectedEntity.id : this.props.params.id;
-        const kind = selectedNode && selectedNode.properties !== undefined && selectedNode.properties.kind === Kind.DDS_ACTIVITY ? Kind.DDS_ACTIVITY : Kind.DDS_FILE;
+        const kind = selectedNode && selectedNode.properties !== undefined && selectedNode.properties.kind === Kind.DDS_ACTIVITY || this.props.location.pathname.includes('activity') ? Kind.DDS_ACTIVITY : Kind.DDS_FILE;
         let metaProps = mainStore.metaProps.slice();
         let errors = this.state.errorText;
         if(Object.keys(errors).length === 0 && errors.constructor === Object) {

--- a/app/scripts/components/globalComponents/provenance.jsx
+++ b/app/scripts/components/globalComponents/provenance.jsx
@@ -460,7 +460,8 @@ class Provenance extends React.Component {
 const styles = {
     btnStyle: {
         margin: 10,
-        width: '80%'
+        width: '80%',
+        minWidth: 168
     },
     dialogStyles: {
         textAlign: 'center',

--- a/app/scripts/components/globalComponents/provenance.jsx
+++ b/app/scripts/components/globalComponents/provenance.jsx
@@ -46,11 +46,11 @@ class Provenance extends React.Component {
         provenanceStore.getActivities();
     }
 
-    componentWillUpdate(nextProps, nextState) {
-        let scale = provenanceStore.scale;
-        let position = provenanceStore.position;
-        let edges = provenanceStore.provEdges && provenanceStore.provEdges.length > 0 ? provenanceStore.provEdges.slice() : [];
-        let nodes = provenanceStore.provNodes && provenanceStore.provNodes.length > 0 ? provenanceStore.provNodes.slice() : [];
+    componentWillUpdate() {
+        const {currentGraph, provEdges, provNodes, position, scale} = provenanceStore;
+        const id = this.props.params.id;
+        const edges = provEdges && provEdges.length > 0 ? provEdges.slice() : currentGraph !== null && currentGraph.id === id ? currentGraph.edges.slice() : [];
+        const nodes = provNodes && provNodes.length > 0 ? provNodes.slice() : currentGraph !== null && currentGraph.id === id ? currentGraph.nodes.slice() : [];
         if(provenanceStore.renderGraph) this.renderProvGraph(edges, nodes, scale, position);
     }
 
@@ -66,7 +66,7 @@ class Provenance extends React.Component {
     }
 
     renderProvGraph(edge, node, scale, position) {
-        provenanceStore.shouldRenderGraph()
+        provenanceStore.shouldRenderGraph();
         let edges = new vis.DataSet(edge);
         let nodes = new vis.DataSet(node);
         let onAddEdgeMode = (data, callback) => {

--- a/app/scripts/components/globalComponents/provenanceActivityManager.jsx
+++ b/app/scripts/components/globalComponents/provenanceActivityManager.jsx
@@ -138,15 +138,14 @@ class ProvenanceActivityManager extends React.Component {
                                 <h2 style={styles.tabHeadline}>Add an Existing Activity</h2>
                                 <AutoComplete
                                     fullWidth={true}
-                                    menuStyle={{maxHeight: 200}}
+                                    menuStyle={styles.autoComplete}
                                     errorText={this.state.floatingErrorText}
                                     floatingLabelText="Type an Existing Activity Name"
                                     dataSource={autoCompleteData}
                                     filter={AutoComplete.caseInsensitiveFilter}
                                     ref={(input) => this.activityNameSearch = input}
                                     openOnFocus={true}
-                                    onNewRequest={(value) => this.chooseActivity(value)}
-                                    underlineStyle={styles.autoCompleteUnderline}/>
+                                    onNewRequest={(value) => this.chooseActivity(value)}/>
                             </Tab>
                         </Tabs>
                 </Dialog>
@@ -283,6 +282,10 @@ class ProvenanceActivityManager extends React.Component {
 }
 
 const styles = {
+    autoComplete: {
+        maxHeight: 200,
+        overflowY: 'auto'
+    },
     provEditor:{
         display: 'flex',
         justifyContent: 'center',

--- a/app/scripts/components/globalComponents/provenanceActivityManager.jsx
+++ b/app/scripts/components/globalComponents/provenanceActivityManager.jsx
@@ -6,6 +6,7 @@ import provenanceStore from '../../stores/provenanceStore';
 import { Color } from '../../theme/customTheme';
 import AutoComplete from 'material-ui/AutoComplete';
 import BaseUtils from '../../util/baseUtils.js';
+import { Kind } from '../../util/urlEnum';
 import Dialog from 'material-ui/Dialog';
 import FlatButton from 'material-ui/FlatButton';
 import RaisedButton from 'material-ui/RaisedButton';
@@ -94,6 +95,12 @@ class ProvenanceActivityManager extends React.Component {
                             labelStyle={styles.btn.label}
                             style={{zIndex: 9999, margin: '10px 0px 10px 0px', minWidth: 168, width: '100%', display: showBtns}}
                             onTouchTap={() => this.openModal('editAct')}/>
+                        <RaisedButton
+                            label="Tag Activity"
+                            primary={true}
+                            labelStyle={styles.btn.label}
+                            style={{zIndex: 9999, margin: '20px 0px 10px 0px', minWidth: 168, width: '100%', display: showBtns}}
+                            onTouchTap={() => this.toggleTagManager()}/>
                         <RaisedButton
                             label="Delete Activity"
                             primary={true}
@@ -278,6 +285,12 @@ class ProvenanceActivityManager extends React.Component {
 
     toggleTab2() {
         this.activityNameSearch.focus();
+    }
+
+    toggleTagManager() {
+        let id = provenanceStore.selectedNode.id;
+        mainStore.getObjectMetadata(id, Kind.DDS_ACTIVITY);
+        mainStore.toggleTagManager();
     }
 }
 

--- a/app/scripts/components/globalComponents/provenanceDetails.jsx
+++ b/app/scripts/components/globalComponents/provenanceDetails.jsx
@@ -16,6 +16,7 @@ class ProvenanceDetails extends React.Component {
             let id = this.props.params.id;
             let versionId = onClickProvNode !== null ? onClickProvNode.id : null;
             let activityName = onClickProvNode !== null && onClickProvNode.properties.kind === 'dds-activity' ? onClickProvNode.properties.name : null;
+            let activityId = onClickProvNode !== null && onClickProvNode.properties.kind === 'dds-activity' ? onClickProvNode.properties.id : null;
             let activityDescription = onClickProvNode !== null && onClickProvNode.properties.kind === 'dds-activity' ? onClickProvNode.properties.description : null;
             let fileName = onClickProvNode !== null && onClickProvNode.properties.file ? onClickProvNode.properties.file.name : null;
             if (fileName === null && onClickProvNode !== null && onClickProvNode.properties.current_version) fileName = onClickProvNode.properties.name;
@@ -31,18 +32,19 @@ class ProvenanceDetails extends React.Component {
                     onClickProvNode.properties.upload.storage_provider.description :
                     onClickProvNode.properties.current_version.upload.storage_provider.description;
             }
-            let fileLink = null;
-            if (fileName !== null) {
-                fileLink = <span><i className="material-icons" style={styles.linkIcon}>link</i>
-                    <a href={UrlGen.routes.version(versionId)} className="external link" onTouchTap={() => this.toggleProv()}>{fileName}</a></span>
+            let link = null;
+            if (fileName !== null || activityName !== null) { // Todo: Create a link for activities as well!!!!!!!!
+                link = <span><i className="material-icons" style={styles.linkIcon}>link</i>
+                    <a href={fileName !== null ? UrlGen.routes.version(versionId) : UrlGen.routes.activities(activityId)} className="external link" onTouchTap={() => this.toggleProv()}>{fileName !== null ? fileName : activityName}</a></span>
             }
-            if (fileId === id || versionId === id) fileLink =
-                <span className="mdl-color-text--grey-800">{fileName}</span>;
+            if (fileId === id || versionId === id) link = <span className="mdl-color-text--grey-800">{fileName}</span>;
+            // if (activityName !== null) link = <span className="mdl-color-text--grey-800">{activityName}</span>;
             let bytes = onClickProvNode !== null && onClickProvNode.properties.upload ? onClickProvNode.properties.upload.size : null;
             if (bytes === null && onClickProvNode !== null && onClickProvNode.properties.kind !== 'dds-activity') bytes = onClickProvNode.properties.current_version.upload.size;
             details = <div className="mdl-cell mdl-cell--12-col" style={styles.details}>
                 <h6 style={styles.listHeader}>
-                    {fileName !== null ? fileLink : <span className="mdl-color-text--grey-800">{activityName}</span>}
+                    {/*{fileName !== null ? link : <span className="mdl-color-text--grey-800">{activityName}</span>}*/}
+                    {link}
                 </h6>
                 <div className="list-block" style={styles.listBlock}>
                     {fileName !== null ? <div className="list-group">

--- a/app/scripts/components/globalComponents/tagCloud.jsx
+++ b/app/scripts/components/globalComponents/tagCloud.jsx
@@ -3,6 +3,7 @@ const { array, string } = PropTypes;
 import { observer } from 'mobx-react';
 import mainStore from '../../stores/mainStore';
 import { Color } from '../../theme/customTheme';
+import { Kind } from '../../util/urlEnum';
 import IconButton from 'material-ui/IconButton';
 import LocalOffer from 'material-ui/svg-icons/maps/local-offer';
 
@@ -39,9 +40,8 @@ class TagCloud extends React.Component {
     }
 
     deleteTag(id, label) {
-        let fileId = this.props.params.id;
         this.id.style.display = 'none';
-        mainStore.deleteTag(id, label, fileId);
+        mainStore.deleteTag(id, label);
     }
 
     openTagManager() {

--- a/app/scripts/components/globalComponents/tagManager.jsx
+++ b/app/scripts/components/globalComponents/tagManager.jsx
@@ -77,7 +77,7 @@ class TagManager extends React.Component {
 
         return (
             <div className="mdl-cell mdl-cell--12-col mdl-color-text--grey-800">
-                <Drawer docked={false} disableSwipeToOpen={true} width={width > 640 ? width*.80 : width} openSecondary={true} open={openTagManager}>
+                <Drawer docked={false} disableSwipeToOpen={true} width={width > 640 ? width*.80 : width} openSecondary={true} open={openTagManager} onRequestChange={() => this.toggleTagManager()}>
                     <div className="mdl-cell mdl-cell--1-col mdl-cell--8-col-tablet mdl-cell--4-col-phone mdl-color-text--grey-800" style={styles.drawer}>
                         <IconButton style={styles.toggleBtn}
                                     onTouchTap={() => this.toggleTagManager()}>

--- a/app/scripts/components/globalComponents/tagManager.jsx
+++ b/app/scripts/components/globalComponents/tagManager.jsx
@@ -46,11 +46,11 @@ class TagManager extends React.Component {
 
     render() {
         const {drawerLoading, entityObj, filesChecked, openTagManager, screenSize, selectedEntity, showTagCloud, showTemplateDetails, tagAutoCompleteList, tagLabels, tagsToAdd, toggleModal} = mainStore;
-        const { selectedNode } = provenanceStore;
+        const { activity, selectedNode } = provenanceStore;
         let autoCompleteData = tagAutoCompleteList && tagAutoCompleteList.length > 0 ? tagAutoCompleteList : [];
         let dialogWidth = screenSize.width < 580 ? {width: '100%'} : {};
         let id = selectedNode && selectedNode.properties !== undefined ? selectedNode.properties.id : selectedEntity !== null ? selectedEntity.id : this.props.params.id;
-        let name = entityObj && filesChecked < 1 ? selectedNode && selectedNode.properties !== undefined ? selectedNode.properties.name : entityObj.name : 'selected files';
+        let name = entityObj && filesChecked < 1 ? selectedNode && selectedNode.properties !== undefined ? selectedNode.properties.name : this.props.location.pathname.includes('activity') && activity !== null ? activity.name : entityObj.name : 'selected files';
         let openDiscardTagsModal = toggleModal && toggleModal.id === 'discardTags' ? toggleModal.open : false;
         let width = screenSize !== null && Object.keys(screenSize).length !== 0 ? screenSize.width : window.innerWidth;
         const modalActions = [
@@ -209,7 +209,7 @@ class TagManager extends React.Component {
 
     addTagsToResource(filesChecked, id, tagsToAdd, toggleModal) {
         const { selectedNode } = provenanceStore;
-        const kind = selectedNode && selectedNode.properties !== undefined && selectedNode.properties.kind === Kind.DDS_ACTIVITY ? Kind.DDS_ACTIVITY : Kind.DDS_FILE
+        const kind = selectedNode && selectedNode.properties !== undefined && selectedNode.properties.kind === Kind.DDS_ACTIVITY || this.props.location.pathname.includes('activity') ? Kind.DDS_ACTIVITY : Kind.DDS_FILE;
         if(!tagsToAdd.length) {
             this.setState({floatingErrorText: 'You must add tags to the list. Type a tag name and press enter.'});
         } else {

--- a/app/scripts/components/globalComponents/tagManager.jsx
+++ b/app/scripts/components/globalComponents/tagManager.jsx
@@ -2,7 +2,9 @@ import React, { PropTypes } from 'react';
 const { object, bool, array } = PropTypes;
 import { observer } from 'mobx-react';
 import mainStore from '../../stores/mainStore';
+import provenanceStore from '../../stores/provenanceStore';
 import BaseUtils from '../../util/baseUtils';
+import { Kind } from '../../util/urlEnum';
 import { Color } from '../../theme/customTheme';
 import MetadataObjectCreator from '../globalComponents/metadataObjectCreator.jsx';
 import MetadataTemplateList from '../globalComponents/metadataTemplateList.jsx';
@@ -38,16 +40,17 @@ class TagManager extends React.Component {
         }
     }
 
-    componentDidUpdate(prevProps) {
+    componentDidUpdate() {
         if(mainStore.openTagManager) this.autocomplete.focus();
     }
 
     render() {
         const {drawerLoading, entityObj, filesChecked, openTagManager, screenSize, selectedEntity, showTagCloud, showTemplateDetails, tagAutoCompleteList, tagLabels, tagsToAdd, toggleModal} = mainStore;
+        const { selectedNode } = provenanceStore;
         let autoCompleteData = tagAutoCompleteList && tagAutoCompleteList.length > 0 ? tagAutoCompleteList : [];
         let dialogWidth = screenSize.width < 580 ? {width: '100%'} : {};
-        let id = selectedEntity !== null ? selectedEntity.id : this.props.params.id;
-        let name = entityObj && filesChecked < 1 ? entityObj.name : 'selected files';
+        let id = selectedNode && selectedNode.properties !== undefined ? selectedNode.properties.id : selectedEntity !== null ? selectedEntity.id : this.props.params.id;
+        let name = entityObj && filesChecked < 1 ? selectedNode && selectedNode.properties !== undefined ? selectedNode.properties.name : entityObj.name : 'selected files';
         let openDiscardTagsModal = toggleModal && toggleModal.id === 'discardTags' ? toggleModal.open : false;
         let width = screenSize !== null && Object.keys(screenSize).length !== 0 ? screenSize.width : window.innerWidth;
         const modalActions = [
@@ -59,7 +62,7 @@ class TagManager extends React.Component {
                 label="ADD TAGS"
                 secondary={true}
                 keyboardFocused={true}
-                onTouchTap={() => this.addTagsToFiles(filesChecked, id, tagsToAdd, toggleModal)} />
+                onTouchTap={() => this.addTagsToResource(filesChecked, id, tagsToAdd, toggleModal)} />
         ];
         let tags = tagsToAdd && tagsToAdd.length > 0 ? tagsToAdd.map((tag)=>{
             return (<div key={BaseUtils.generateUniqueKey()} className="chip">
@@ -67,9 +70,9 @@ class TagManager extends React.Component {
                 <span className="closebtn" onTouchTap={() => this.deleteTag(tag.label)}>&times;</span>
             </div>)
         }) : null;
-        let tagLbls = tagLabels.map((label)=>{
+        let tagLbls = tagLabels.map((tag)=>{
             return (
-                <li key={BaseUtils.generateUniqueKey()} style={styles.tagLabels} onTouchTap={() => this.addTagToCloud(label.label)}>{label.label}
+                <li key={BaseUtils.generateUniqueKey()} style={styles.tagLabels} onTouchTap={() => this.addTagToCloud(tag.label)}>{tag.label}
                     <span className="mdl-color-text--grey-600">,</span>
                 </li>
             )
@@ -89,7 +92,7 @@ class TagManager extends React.Component {
                             <Tab label="Tags" style={styles.tabStyles}>
                                 <div className="mdl-cell mdl-cell--12-col mdl-cell--8-col-tablet mdl-cell--4-col-phone mdl-color-text--grey-800" >
                                     <h5 className="mdl-color-text--grey-600" style={styles.heading}>Add Tags to {name}
-                                        <IconButton tooltip={<span>Tag your files with relevant keywords<br/> that can help with search and organization of content</span>}
+                                        <IconButton tooltip={<span>Tag your resources with relevant keywords<br/> that can help with search and organization of content</span>}
                                                     tooltipPosition="bottom-center"
                                                     iconStyle={styles.infoIcon.size}
                                                     style={styles.infoIcon}>
@@ -102,7 +105,7 @@ class TagManager extends React.Component {
                                         ref={(input) => this.autocomplete = input}
                                         fullWidth={true}
                                         style={styles.autoComplete}
-                                        floatingLabelText="Type a Tag Label Here"
+                                        floatingLabelText="Type a label or comma separated list of labels"
                                         filter={AutoComplete.fuzzyFilter}
                                         dataSource={autoCompleteData}
                                         errorText={this.state.floatingErrorText}
@@ -137,7 +140,7 @@ class TagManager extends React.Component {
                                     <RaisedButton label={'Apply'}
                                                   labelStyle={styles.buttonLabel}
                                                   style={styles.applyBtn}
-                                                  onTouchTap={() => this.addTagsToFiles(filesChecked, id, tagsToAdd, toggleModal)}/>
+                                                  onTouchTap={() => this.addTagsToResource(filesChecked, id, tagsToAdd, toggleModal)}/>
                                     <RaisedButton label={'Cancel'}
                                                   labelStyle={styles.buttonLabel}
                                                   style={styles.cancelBtn}
@@ -173,29 +176,40 @@ class TagManager extends React.Component {
         if(!mainStore.metaTemplates.length) mainStore.loadMetadataTemplates('');
     }
 
-    addTagToCloud(label) {
+    checkIfTagAlreadyUsed(tag) {
+        let tags = mainStore.tagsToAdd;
         let clearText = ()=> {
             this.autocomplete.setState({searchText:''});
             this.autocomplete.focus();
         };
-        if(label && !label.indexOf(' ') <= 0) {
-            let tags = mainStore.tagsToAdd;
-            if (tags.some((el) => { return el.label === label.trim(); })) {
-                this.setState({floatingErrorText: label + ' tag is already in the list'});
-                setTimeout(()=>{
-                    this.setState({floatingErrorText: ''});
-                    clearText();
-                }, 2000)
+        if (tags.some((el) => { return el.label === tag.trim(); })) {
+            this.setState({floatingErrorText: tag + ' tag is already in the list'});
+            setTimeout(()=>{
+                this.setState({floatingErrorText: ''});
+                clearText();
+            }, 2000)
+        } else {
+            tags.push({label: tag.trim()});
+            mainStore.defineTagsToAdd(tags);
+            setTimeout(()=>clearText(), 500);
+            this.setState({floatingErrorText: ''})
+        }
+    }
+
+    addTagToCloud(tag) {
+        if(tag && !tag.indexOf(' ') <= 0) {
+            if (tag.indexOf(',') > -1) tag = tag.split(',');
+            if(tag && tag.constructor === Array) {
+                tag.forEach((label) => this.checkIfTagAlreadyUsed(label))
             } else {
-                tags.push({label: label.trim()});
-                mainStore.defineTagsToAdd(tags);
-                setTimeout(()=>clearText(), 500);
-                this.setState({floatingErrorText: ''})
+                this.checkIfTagAlreadyUsed(tag);
             }
         }
     }
 
-    addTagsToFiles(filesChecked, id, tagsToAdd, toggleModal) {
+    addTagsToResource(filesChecked, id, tagsToAdd, toggleModal) {
+        const { selectedNode } = provenanceStore;
+        const kind = selectedNode && selectedNode.properties !== undefined && selectedNode.properties.kind === Kind.DDS_ACTIVITY ? Kind.DDS_ACTIVITY : Kind.DDS_FILE
         if(!tagsToAdd.length) {
             this.setState({floatingErrorText: 'You must add tags to the list. Type a tag name and press enter.'});
         } else {
@@ -204,7 +218,7 @@ class TagManager extends React.Component {
                     mainStore.appendTags(filesChecked[i], 'dds-file', tagsToAdd);
                 }
             } else {
-                mainStore.appendTags(id, 'dds-file', tagsToAdd);
+                mainStore.appendTags(id, kind, tagsToAdd);
             }
             if(toggleModal && toggleModal.id === 'discardTags') {
                 this.discardTags();

--- a/app/scripts/components/projectComponents/projectList.jsx
+++ b/app/scripts/components/projectComponents/projectList.jsx
@@ -16,10 +16,7 @@ import RaisedButton from 'material-ui/RaisedButton';
 class ProjectList extends React.Component {
 
     render() {
-        const { loading, projects, projectRoles, responseHeaders } = mainStore;
-        let headers = responseHeaders && responseHeaders !== null ? responseHeaders : null;
-        let nextPage = headers !== null && !!headers['x-next-page'] ? headers['x-next-page'][0] : null;
-        let totalProjects = headers !== null && !!headers['x-total'] ? headers['x-total'][0] : null;
+        const { loading, nextPage, projects, projectRoles, totalItems } = mainStore;
         let projectList = projects ? projects.map((project) => {
             let role = projectRoles.get(project.id);
             return (
@@ -48,7 +45,7 @@ class ProjectList extends React.Component {
                     <Loaders {...this.props} />
                 </div>
                 { projectList }
-                {projects && projects.length < totalProjects ? <div className="mdl-cell mdl-cell--12-col">
+                {projects && projects.length < totalItems ? <div className="mdl-cell mdl-cell--12-col">
                     <RaisedButton
                         label={loading ? "Loading..." : "Load More"}
                         secondary={true}

--- a/app/scripts/pages/activity.jsx
+++ b/app/scripts/pages/activity.jsx
@@ -1,0 +1,42 @@
+import React from 'react'
+import { observer } from 'mobx-react';
+import mainStore from '../stores/mainStore';
+import provenanceStore from '../stores/provenanceStore';
+import { Kind, Path } from '../util/urlEnum';
+import ActivityDetails from '../components/globalComponents/activityDetails.jsx';
+import ActivityOptions from '../components/fileComponents/fileOptions.jsx';
+import TagManager from '../components/globalComponents/tagManager.jsx';
+
+@observer
+class Activity extends React.Component {
+
+    componentDidMount() {
+        this._loadActivity();
+    }
+
+    componentDidUpdate(prevProps) {
+        if(prevProps.params.id !== this.props.params.id) {
+            this._loadActivity();
+        }
+    }
+
+    _loadActivity() {
+        let id = this.props.params.id;
+        mainStore.setSelectedEntity(null, null);
+        provenanceStore.getActivity(id, Path.ACTIVITIES);
+        mainStore.getObjectMetadata(id, Kind.DDS_ACTIVITY);
+        mainStore.getTags(id, Kind.DDS_ACTIVITY);
+        mainStore.getTagLabels();
+    }
+
+    render() {
+        return (
+            <div>
+                <ActivityDetails {...this.props} />
+                <TagManager {...this.props} />
+            </div>
+        );
+    }
+}
+
+export default Activity;

--- a/app/scripts/pages/app.jsx
+++ b/app/scripts/pages/app.jsx
@@ -82,6 +82,11 @@ class App extends React.Component {
         this.showToasts();
     }
 
+    componentWillReceiveProps(nextProps) {
+        const routeChanged = nextProps.location !== this.props.location;
+        mainStore.toggleBackButtonVisibility(routeChanged);
+    }
+
     handleResize() {
         mainStore.getScreenSize(window.innerHeight, window.innerWidth);
     }

--- a/app/scripts/pages/file.jsx
+++ b/app/scripts/pages/file.jsx
@@ -20,6 +20,11 @@ class File extends React.Component {
         }
     }
 
+    componentWillReceiveProps(nextProps) {
+        const routeChanged = nextProps.location !== this.props.location;
+        mainStore.toggleBackButtonVisibility(routeChanged);
+    }
+
     _loadFile() {
         let id = this.props.params.id;
         mainStore.setSelectedEntity(null, null);

--- a/app/scripts/pages/folder.jsx
+++ b/app/scripts/pages/folder.jsx
@@ -23,6 +23,11 @@ class Folder extends React.Component {
         }
     }
 
+    componentWillReceiveProps(nextProps) {
+        const routeChanged = nextProps.location !== this.props.location;
+        mainStore.toggleBackButtonVisibility(routeChanged);
+    }
+
     _loadFolder() {
         let path = Path.FOLDER;
         let id = this.props.params.id;

--- a/app/scripts/pages/version.jsx
+++ b/app/scripts/pages/version.jsx
@@ -19,6 +19,11 @@ class Version extends React.Component {
         }
     }
 
+    componentWillReceiveProps(nextProps) {
+        const routeChanged = nextProps.location !== this.props.location;
+        mainStore.toggleBackButtonVisibility(routeChanged);
+    }
+
     _loadVersion() {
         let id = this.props.params.id;
         mainStore.setSelectedEntity(null, null);

--- a/app/scripts/routes.js
+++ b/app/scripts/routes.js
@@ -1,7 +1,5 @@
 import React from 'react';
 import { Router, Route, IndexRoute, Redirect, hashHistory } from 'react-router';
-import authStore from './stores/authStore';
-import mainStore from './stores/mainStore';
 import App from './pages/app.jsx';
 import Login from './pages/login.jsx';
 import Home from './pages/home.jsx';
@@ -11,6 +9,7 @@ import PublicPrivacy from './pages/publicPrivacy.jsx';
 import Project from './pages/project.jsx';
 import Folder from './pages/folder.jsx';
 import File from './pages/file.jsx';
+import Activity from './pages/activity.jsx';
 import Agents from './pages/agents.jsx';
 import Agent from './pages/agent.jsx';
 import Results from './pages/results.jsx';
@@ -29,6 +28,7 @@ const routes = (
             <Route path="project/:id" component={ Project }/>
             <Route path="folder/:id" component={ Folder } />
             <Route path="file/:id" component={ File } />
+            <Route path="activity/:id" component={ Activity } />
             <Route path="agents" component={ Agents } />
             <Route path="agent/:id" component={ Agent } />
             <Route path="results" component={ Results } />

--- a/app/scripts/stores/mainStore.js
+++ b/app/scripts/stores/mainStore.js
@@ -562,6 +562,10 @@ export class MainStore {
                 this.metaObjProps = json.results.map((prop) => {
                     return prop.properties.map((prop) => {
                         return {
+                            object: {
+                                kind: prop.object.kind,
+                                id: prop.object.id
+                            },
                             template: prop.template,
                             key: prop.template_property.key,
                             id: prop.template_property.id,
@@ -570,6 +574,22 @@ export class MainStore {
                     })
                 });
             }).catch(ex => this.handleErrors(ex))
+    }
+
+    @action deleteObjectMetadata(object, template) {
+        const index = this.objectMetadata.findIndex(o => o.template.id === template.id);
+        const itemToDelete = this.objectMetadata.filter((o) => {return o.template.id === template.id});
+        this.objectMetadata = this.objectMetadata.filter((o) => o.template.id !== template.id);
+        this.transportLayer.deleteObjectMetadata(object, template.id)
+            .then(this.checkResponse)
+            .then(response => {})
+            .then(() => {
+                this.addToast(`File metadata from ${template.name} has been deleted`);
+            }).catch((ex) => {
+            this.addToast(`Failed to delete file metadata from ${template.name}`);
+            this.objectMetadata.splice(index, 1, itemToDelete);
+            this.handleErrors(ex)
+        });
     }
 
     @action getUserNameFromAuthProvider(text, id) {

--- a/app/scripts/stores/mainStore.js
+++ b/app/scripts/stores/mainStore.js
@@ -562,15 +562,8 @@ export class MainStore {
                 this.metaObjProps = json.results.map((prop) => {
                     return prop.properties.map((prop) => {
                         return {
-                            object: {
-                                kind: prop.object.kind,
-                                id: prop.object.id
-                            },
-                            template: prop.template,
-                            key: prop.template_property.key,
-                            id: prop.template_property.id,
-                            value: prop.value
-                        };
+                            key: prop.template_property.key, id: prop.template_property.id, value: prop.value
+                        }
                     })
                 });
             }).catch(ex => this.handleErrors(ex))
@@ -790,8 +783,8 @@ export class MainStore {
             .then(this.checkResponse)
             .then(response => response.json())
             .then(() => {
-                this.addToast('Added ' + msg + ' as tags to all selected files.');
-                this.getTags(id, Kind.DDS_FILE);
+                this.addToast('Added ' + msg + ' as tags to all selected resources.');
+                this.getTags(id, kind);
                 this.loading = false;
             }).catch((ex) => {
             this.addToast('Failed to add tags');
@@ -1412,9 +1405,9 @@ export class MainStore {
         });
     }
 
-    @action createMetadataObject(kind, fileId, templateId, properties) {
+    @action createMetadataObject(kind, id, templateId, properties) {
         this.drawerLoading = true;
-        this.transportLayer.createMetadataObject(kind, fileId, templateId, properties)
+        this.transportLayer.createMetadataObject(kind, id, templateId, properties)
             .then(this.checkResponse)
             .then(response => response.json())
             .then((json) => {
@@ -1422,7 +1415,7 @@ export class MainStore {
                 this.createMetadataObjectSuccess(json);
             }).catch((ex) => {
             if (ex.response.status === 409) {
-                this.updateMetadataObject(kind, fileId, templateId, properties);
+                this.updateMetadataObject(kind, id, templateId, properties);
             } else {
                 this.addToast('Failed to add new metadata object');
                 this.handleErrors(ex)
@@ -1430,8 +1423,8 @@ export class MainStore {
         })
     }
 
-    @action updateMetadataObject(kind, fileId, templateId, properties) {
-        this.transportLayer.updateMetadataObject(kind, fileId, templateId, properties)
+    @action updateMetadataObject(kind, id, templateId, properties) {
+        this.transportLayer.updateMetadataObject(kind, id, templateId, properties)
             .then(this.checkResponse)
             .then(response => response.json())
             .then((json) => {
@@ -1466,7 +1459,9 @@ export class MainStore {
         this.objectMetadata.push(json);
         this.metaObjProps = this.objectMetadata.map((prop) => {
             return prop.properties.map((prop) => {
-                return {key: prop.template_property.key, id: prop.template_property.id, value: prop.value};
+                return {
+                    key: prop.template_property.key, id: prop.template_property.id, value: prop.value
+                }
             })
         });
     }

--- a/app/scripts/stores/mainStore.js
+++ b/app/scripts/stores/mainStore.js
@@ -561,7 +561,12 @@ export class MainStore {
                 this.objectMetadata = json.results;
                 this.metaObjProps = json.results.map((prop) => {
                     return prop.properties.map((prop) => {
-                        return {key: prop.template_property.key, id: prop.template_property.id, value: prop.value};
+                        return {
+                            template: prop.template,
+                            key: prop.template_property.key,
+                            id: prop.template_property.id,
+                            value: prop.value
+                        };
                     })
                 });
             }).catch(ex => this.handleErrors(ex))
@@ -1394,7 +1399,7 @@ export class MainStore {
             .then(response => response.json())
             .then((json) => {
                 this.addToast('A new metadata object was created.');
-                this.createMetadataObjectSuccess(fileId, kind, json);
+                this.createMetadataObjectSuccess(json);
             }).catch((ex) => {
             if (ex.response.status === 409) {
                 this.updateMetadataObject(kind, fileId, templateId, properties);
@@ -1411,7 +1416,7 @@ export class MainStore {
             .then(response => response.json())
             .then((json) => {
                 this.addToast('This metadata object was updated.');
-                this.createMetadataObjectSuccess(fileId, kind, json);
+                this.createMetadataObjectSuccess(json);
             }).catch((ex) => {
             this.addToast('Failed to update metadata object');
             this.handleErrors(ex)
@@ -1433,10 +1438,11 @@ export class MainStore {
         })
     }
 
-    @action createMetadataObjectSuccess(id, kind, json) {
+    @action createMetadataObjectSuccess(json) {
         this.drawerLoading = false;
         this.showBatchOps = false;
         this.showTemplateDetails = false;
+        this.objectMetadata = this.objectMetadata.filter((o) => o.template.id !== json.template.id);
         this.objectMetadata.push(json);
         this.metaObjProps = this.objectMetadata.map((prop) => {
             return prop.properties.map((prop) => {

--- a/app/scripts/stores/provenanceStore.js
+++ b/app/scripts/stores/provenanceStore.js
@@ -64,7 +64,7 @@ export class ProvenanceStore {
         this.relTo = null;
         this.relMsg = null;
         this.removeFileFromProvBtn = false;
-        this.renderGraph = false
+        this.renderGraph = false;
         this.scale = null;
         this.selectedNode = {};
         this.selectedEdge = null;
@@ -348,10 +348,11 @@ export class ProvenanceStore {
                 edges.push(this.updatedGraphItem[0]);
                 this.shouldRenderGraph();
                 this.provEdges = edges;
+                this.currentGraph.edges = edges;
             }).catch((ex) => {
             mainStore.addToast('Failed to add new relation');
-                mainStore.handleErrors(ex)
-            })
+            mainStore.handleErrors(ex)
+        })
     }
 
     @action deleteProvItem(data, id) {
@@ -368,15 +369,17 @@ export class ProvenanceStore {
                 this.shouldRenderGraph();
                 if(data.hasOwnProperty('from')){
                     this.provEdges = this.provEdges.filter(obj => obj.id !== data.id);
+                    this.currentGraph.edges = this.provEdges;
                 } else {
                     this.provNodes = this.provNodes.filter(obj => obj.id !== data.id);
+                    this.currentGraph.nodes = provNodes;
                     this.getActivities();
                 }
                 this.updatedGraphItem = item;
             }).catch((ex) => {
-                mainStore.addToast('Failed to delete ' + msg);
-                mainStore.handleErrors(ex)
-            });
+            mainStore.addToast('Failed to delete ' + msg);
+            mainStore.handleErrors(ex)
+        });
     }
 
     @action addProvActivity(name, desc) {
@@ -387,9 +390,9 @@ export class ProvenanceStore {
                 mainStore.addToast('New Activity Added');
                 this.addProvActivitySuccess(json);
             }).catch((ex) => {
-                mainStore.addToast('Failed to add new actvity');
-                mainStore.handleErrors(ex)
-            })
+            mainStore.addToast('Failed to add new actvity');
+            mainStore.handleErrors(ex)
+        })
     }
 
     @action addProvActivitySuccess(json) {
@@ -410,8 +413,9 @@ export class ProvenanceStore {
         });
         let nodes = this.provNodes.slice();
         nodes.push(this.updatedGraphItem[0]);
-        this.shouldRenderGraph();
         this.provNodes = nodes;
+        this.currentGraph.nodes = nodes;
+        this.shouldRenderGraph();
         mainStore.addToast(json.name+' was added to the graph');
     }
 
@@ -446,6 +450,7 @@ export class ProvenanceStore {
                 this.activity = json;
                 this.shouldRenderGraph();
                 this.provNodes = nodes;
+                this.currentGraph.nodes = nodes;
                 this.showProvCtrlBtns = false;
             }).catch(ex =>mainStore.handleErrors(ex))
     }
@@ -457,6 +462,7 @@ export class ProvenanceStore {
             .then(() => {
                 mainStore.addToast(`${name} activity was deleted!`);
                 this.provNodes = this.provNodes.filter(obj => obj.id !== id);
+                this.currentGraph.nodes = this.provNodes;
             }).catch((ex) => {
             mainStore.addToast(`Failed to delete ${name}`);
             mainStore.handleErrors(ex)
@@ -501,6 +507,7 @@ export class ProvenanceStore {
         nodes.push(this.updatedGraphItem[0]);
         this.shouldRenderGraph();
         this.provNodes = nodes;
+        this.currentGraph.nodes = nodes;
     }
 
     @action switchRelationFromTo(from, to){
@@ -553,8 +560,8 @@ export class ProvenanceStore {
             .then((json) => {
                 this.provFileVersions = json.results
             }).catch((ex) => {
-                mainStore.handleErrors(ex)
-            })
+            mainStore.handleErrors(ex)
+        })
     }
 
     @action createGraph(graph) {

--- a/app/scripts/stores/provenanceStore.js
+++ b/app/scripts/stores/provenanceStore.js
@@ -552,6 +552,7 @@ export class ProvenanceStore {
 
     @action toggleProvView() {
         this.toggleProv = !this.toggleProv;
+        this.selectedNode = {};
         if(this.toggleProv !== true) { //clear old graph on close of provenance view
             this.provEdges = [];
             this.provNodes = [];

--- a/app/scripts/transportLayer.js
+++ b/app/scripts/transportLayer.js
@@ -57,6 +57,13 @@ const transportLayer = {
         };
         return fetch(DDS_BASE_URI+apiPrefix+Path.ACTIVITIES, getFetchParams('post', authStore.appConfig.apiToken, body))
     },
+    editProvActivity: (id, name, desc) => {
+        const body = {
+            "name": name,
+            "description": desc
+        };
+        return fetch(DDS_BASE_URI+apiPrefix+Path.ACTIVITIES+id, getFetchParams('put', authStore.appConfig.apiToken, body))
+    },
     getProvFileVersions: (id) => {
         return fetch(`${DDS_BASE_URI+apiPrefix+Path.FILE+id}/${Path.VERSIONS}`, getFetchParams('get', authStore.appConfig.apiToken))
     },
@@ -319,17 +326,17 @@ const transportLayer = {
     deleteObjectMetadata: (object, templateId) => {
         return fetch(`${DDS_BASE_URI+apiPrefix+Path.META+object.kind}/${object.id}/${templateId}`, getFetchParams('delete', authStore.appConfig.apiToken))
     },
-    createMetadataObject: (kind, fileId, templateId, properties) => {
+    createMetadataObject: (kind, id, templateId, properties) => {
         const body = {
             "properties": properties
         };
-        return fetch(`${DDS_BASE_URI+apiPrefix+Path.META+kind}/${fileId}/${templateId}`, getFetchParams('post', authStore.appConfig.apiToken, body))
+        return fetch(`${DDS_BASE_URI+apiPrefix+Path.META+kind}/${id}/${templateId}`, getFetchParams('post', authStore.appConfig.apiToken, body))
     },
-    updateMetadataObject: (kind, fileId, templateId, properties) => {
+    updateMetadataObject: (kind, id, templateId, properties) => {
         const body = {
             "properties": properties
         };
-        return fetch(`${DDS_BASE_URI+apiPrefix+Path.META+kind}/${fileId}/${templateId}`, getFetchParams('put', authStore.appConfig.apiToken, body))
+        return fetch(`${DDS_BASE_URI+apiPrefix+Path.META+kind}/${id}/${templateId}`, getFetchParams('put', authStore.appConfig.apiToken, body))
     },
     createMetadataProperty: (id, name, label, desc, type) => {
         const body = {
@@ -371,23 +378,6 @@ const transportLayer = {
         };
         return fetch(DDS_BASE_URI+apiPrefix+Path.SEARCH, getFetchParams('post', authStore.appConfig.apiToken, body))
     },
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 };
 
 export default transportLayer

--- a/app/scripts/transportLayer.js
+++ b/app/scripts/transportLayer.js
@@ -316,6 +316,9 @@ const transportLayer = {
     deleteMetadataProperty: (id) => {
         return fetch(DDS_BASE_URI+apiPrefix+Path.TEMPLATE_PROPERTIES+id, getFetchParams('delete', authStore.appConfig.apiToken))
     },
+    deleteObjectMetadata: (object, templateId) => {
+        return fetch(`${DDS_BASE_URI+apiPrefix+Path.META+object.kind}/${object.id}/${templateId}`, getFetchParams('delete', authStore.appConfig.apiToken))
+    },
     createMetadataObject: (kind, fileId, templateId, properties) => {
         const body = {
             "properties": properties

--- a/app/scripts/util/urlEnum.js
+++ b/app/scripts/util/urlEnum.js
@@ -41,5 +41,6 @@ export const Path = Object.freeze({
 export const Kind = Object.freeze({
     DDS_FILE: 'dds-file',
     DDS_FOLDER: 'dds-folder',
-    DDS_PROJECT: 'dds-project'
+    DDS_PROJECT: 'dds-project',
+    DDS_ACTIVITY: 'dds-activity'
 });

--- a/app/scripts/util/urlEnum.js
+++ b/app/scripts/util/urlEnum.js
@@ -10,6 +10,7 @@ export const UrlGen = {
         folder: (folderId) => '/#/folder/' + folderId,
         file: (fileId) => '/#/file/' + fileId,
         version: (versionId) => '/#/version/' + versionId,
+        activities: (activityId) => '/#/activity/' + activityId,
         agents: () => '/#/agents',
         agent: (agentId) => '/#/agent/' + agentId
     }


### PR DESCRIPTION
Allows metadata to be added to activities. 

Also includes:

- Improvements to graph rendering. Caches graph in state and if the starting node is the same it renders the old graph state rather than rendering a new graph. This way of the user has expanded out the graph and then navigates to view an activity when they come back to provenance view their graph is still expanded. 

- Adds ability to use a comma separated list to define tags to add to a file or activity

- Adds an activity details view. This is accessed by clicking on the activity node on the graph and then using the link that is displayed in the editor.