### PR TITLE
Fix possible 404 errors when getting all project permissions

### DIFF
--- a/app/scripts/stores/mainStore.js
+++ b/app/scripts/stores/mainStore.js
@@ -219,9 +219,10 @@ export class MainStore {
                 } else {
                     this.projects = [...this.projects, ...results];
                 }
+                const userId = authStore.currentUser.id !== undefined ? authStore.currentUser.id : this.currentUser.id !== undefined ? this.currentUser.id : null;
                 this.projects.forEach((p) => {
-                    this.getAllProjectPermissions(p.id, authStore.currentUser.id)
-                })
+                    userId !== null ? this.getAllProjectPermissions(p.id, userId) : null;
+                });
                 this.responseHeaders = headers;
                 this.loading = false;
             }).catch(ex => this.handleErrors(ex))


### PR DESCRIPTION
This is a patch to go to production asap. 

I noticed that for some reason in production `authStore.currentUser` is not set before this call is made and so sometimes it throws a 404. I don't see this problem in ua_test or dev though. (??) 

I've added this additional check to make sure this never causes a 404. The worst possible case in this scenario is that neither user information in the authStore or the mainStore is populated and then the calls don't get made and the project roles will not show up on project cards.