### PR TITLE
Fix all drawers opening in firefox when tagManager is opened

### DIFF
--- a/app/scripts/components/globalComponents/tagManager.jsx
+++ b/app/scripts/components/globalComponents/tagManager.jsx
@@ -30,6 +30,7 @@ class TagManager extends React.Component {
             timeout: null,
             searchText: ''
         };
+        this.focusAutocomplete = _.debounce(this.focusAutocomplete ,500);
     }
 
     componentDidMount() {
@@ -41,7 +42,7 @@ class TagManager extends React.Component {
     }
 
     componentDidUpdate() {
-        if(mainStore.openTagManager) this.autocomplete.focus();
+        if(mainStore.openTagManager && !mainStore.isFirefox) this.focusAutocomplete(); // Using _.debouce() here to avoid this being called twice from list item menu
     }
 
     render() {
@@ -102,7 +103,7 @@ class TagManager extends React.Component {
                                 </div>
                                 <div className="mdl-cell mdl-cell--12-col mdl-color-text--grey-600" style={styles.autoCompleteContainer}>
                                     <AutoComplete
-                                        ref={(input) => this.autocomplete = input}
+                                        ref={(input) => this.tagAutocomplete = input}
                                         fullWidth={true}
                                         style={styles.autoComplete}
                                         floatingLabelText="Type a label or comma separated list of labels"
@@ -112,7 +113,7 @@ class TagManager extends React.Component {
                                         onNewRequest={(value) => this.addTagToCloud(value)}
                                         onUpdateInput={this.handleUpdateInput.bind(this)}
                                         underlineStyle={styles.autoCompleteUnderline}/>
-                                    <IconButton onTouchTap={() => this.addTagToCloud(this.autocomplete.state.searchText)}
+                                    <IconButton onTouchTap={() => this.addTagToCloud(this.tagAutocomplete.state.searchText)}
                                                 iconStyle={styles.addTagIconBtn.size}
                                                 style={styles.addTagIconBtn}>
                                         <AddCircle color={Color.blue}/>
@@ -171,6 +172,10 @@ class TagManager extends React.Component {
         )
     }
 
+    focusAutocomplete() {
+        this.tagAutocomplete.refs.searchTextField.input.focus()
+    }
+
     activeTab() {
         if(mainStore.tagsToAdd.length) mainStore.toggleModals('discardTags');
         if(!mainStore.metaTemplates.length) mainStore.loadMetadataTemplates('');
@@ -179,8 +184,8 @@ class TagManager extends React.Component {
     checkIfTagAlreadyUsed(tag) {
         let tags = mainStore.tagsToAdd;
         let clearText = ()=> {
-            this.autocomplete.setState({searchText:''});
-            this.autocomplete.focus();
+            this.tagAutocomplete.setState({searchText:''});
+            this.tagAutocomplete.refs.searchTextField.input.focus()
         };
         if (tags.some((el) => { return el.label === tag.trim(); })) {
             this.setState({floatingErrorText: tag + ' tag is already in the list'});
@@ -267,7 +272,7 @@ class TagManager extends React.Component {
         mainStore.toggleTagManager();
         mainStore.defineTagsToAdd([]);
         if(mainStore.showTagCloud) this.toggleTagCloud();
-        if(this.autocomplete.state.searchText !== '') this.autocomplete.setState({searchText:''});
+        if(this.tagAutocomplete.state.searchText !== '') this.tagAutocomplete.setState({searchText:''});
     }
 }
 
@@ -393,7 +398,7 @@ const styles = {
 
 TagManager.propTypes = {
     drawerLoading: bool,
-    openTagManager: bool,
+    openTagsManager: bool,
     showTemplateDetails: bool,
     screenSize: object,
     entityObj: object,

--- a/app/scripts/components/globalComponents/tagManager.jsx
+++ b/app/scripts/components/globalComponents/tagManager.jsx
@@ -398,7 +398,7 @@ const styles = {
 
 TagManager.propTypes = {
     drawerLoading: bool,
-    openTagsManager: bool,
+    openTagManager: bool,
     showTemplateDetails: bool,
     screenSize: object,
     entityObj: object,

--- a/app/scripts/stores/mainStore.js
+++ b/app/scripts/stores/mainStore.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { observable, computed, action, map } from 'mobx';
 import cookie from 'react-cookie';
+import UAParser from 'ua-parser-js';
 import authStore from '../stores/authStore';
 import provenanceStore from '../stores/provenanceStore';
 import transportLayer from '../transportLayer';
@@ -36,6 +37,7 @@ export class MainStore {
     @observable hideUploadProgress
     @observable isListItem
     @observable isSafari
+    @observable isFirefox
     @observable itemsSelected
     @observable leftNavIndex
     @observable listItems
@@ -128,6 +130,7 @@ export class MainStore {
         this.isFolderUpload = false;
         this.isListItem = false;
         this.isSafari = false;
+        this.isFirefox = false;
         this.itemsSelected = null;
         this.leftNavIndex = null;
         this.listItems = [];
@@ -1587,7 +1590,8 @@ export class MainStore {
 
     @action getDeviceType(device) {
         this.device = device;
-        this.isSafari = /constructor/i.test(window.HTMLElement);
+        this.isSafari = UAParser().browser.name === 'Safari';
+        this.isFirefox = UAParser().browser.name === 'Firefox';
     }
 
     @action getScreenSize(height, width) {

--- a/package.json
+++ b/package.json
@@ -82,7 +82,8 @@
     "react-cookie": "^0.3.4",
     "react-dom": "15.4.2",
     "react-router": "^3.0.0",
-    "react-tap-event-plugin": "^2.0.1"
+    "react-tap-event-plugin": "^2.0.1",
+    "ua-parser-js": "^0.7.17"
   },
   "jest": {
     "verbose": true,


### PR DESCRIPTION
On Firefox, for some reason if MUI autocompletes are used inside of drawers when the autocomplete is focused in the componentDidUpdate() lifecycle method then all of the drawers open simultaneously.

This is a temporary fix for #770 until a better solution can be found