### PR TITLE
Add retry logic for provenance UI

### DIFF
--- a/app/scripts/components/globalComponents/metadataTemplateManager.jsx
+++ b/app/scripts/components/globalComponents/metadataTemplateManager.jsx
@@ -28,7 +28,7 @@ class MetadataTemplateManager extends React.Component {
             <div className="mdl-cell mdl-cell--12-col mdl-color-text--grey-800">
                 <Drawer disableSwipeToOpen={true} width={width > 640 ? width*.80 : width} openSecondary={true} open={openMetadataManager}>
                     <div className="mdl-cell mdl-cell--1-col mdl-cell--8-col-tablet mdl-cell--4-col-phone mdl-color-text--grey-800"
-                         style={{marginTop: 85}}>
+                         style={styles.drawerTopMargin}>
                         <IconButton style={styles.toggleBtn}
                                     onTouchTap={() => this.toggleMetadataManager()}>
                             <NavigationClose />
@@ -56,6 +56,9 @@ const styles = {
         top: 200,
         left: 0,
         right: 0
+    },
+    drawerTopMargin: {
+        marginTop: 65
     },
     toggleBtn: {
         margin: '5px 0px 5px 0px',

--- a/app/scripts/components/globalComponents/metadataTemplateOptions.jsx
+++ b/app/scripts/components/globalComponents/metadataTemplateOptions.jsx
@@ -115,7 +115,7 @@ const styles = {
     },
     menuIconBtn: {
         position: 'absolute',
-        top: 90 ,
+        top: 70,
         right: 5,
         zIndex: 200
     },

--- a/app/scripts/components/globalComponents/provenance.jsx
+++ b/app/scripts/components/globalComponents/provenance.jsx
@@ -476,13 +476,13 @@ const styles = {
     },
     closeEditorIcon: {
         position: 'absolute',
-        top: 88,
+        top: 68,
         left: 10,
         zIndex: 9999
     },
     closeGraphIcon: {
         position: 'absolute',
-        top: 88,
+        top: 68,
         left: 2,
         zIndex: 9999
     },
@@ -517,7 +517,7 @@ const styles = {
     },
     openEditorIcon: {
         position: 'absolute',
-        top: 90,
+        top: 70,
         right: 10,
         zIndex: 200
     },

--- a/app/scripts/components/globalComponents/tagManager.jsx
+++ b/app/scripts/components/globalComponents/tagManager.jsx
@@ -329,7 +329,7 @@ const styles = {
         zIndex: '5000'
     },
     drawer: {
-        marginTop: 65
+        marginTop: 45
     },
     drawerLoader: {
         position: 'absolute',

--- a/app/scripts/components/globalComponents/uploadManager.jsx
+++ b/app/scripts/components/globalComponents/uploadManager.jsx
@@ -64,7 +64,7 @@ class UploadManager extends React.Component {
             <div style={styles.fileUpload}>
                 <div className="mdl-cell mdl-cell--12-col mdl-color-text--grey-800">
                     <Drawer docked={false} disableSwipeToOpen={true} width={width} openSecondary={true} open={openUploadManager} onRequestChange={() => this.toggleUploadManager()}>
-                        <div className="mdl-cell mdl-cell--1-col mdl-cell--8-col-tablet mdl-cell--4-col-phone mdl-color-text--grey-800" style={{marginTop: 65}}>
+                        <div className="mdl-cell mdl-cell--1-col mdl-cell--8-col-tablet mdl-cell--4-col-phone mdl-color-text--grey-800" style={styles.drawerTopMargin}>
                             <IconButton style={styles.toggleBtn}
                                         onTouchTap={() => this.toggleUploadManager()}>
                                 <NavigationClose />
@@ -278,6 +278,9 @@ const styles = {
         color: Color.red,
         verticalAlign: 'middle',
         marginRight: 3
+    },
+    drawerTopMargin: {
+        marginTop: 45
     },
     dropzoneContainer: {
         margin: '0 auto',

--- a/app/scripts/stores/provenanceStore.js
+++ b/app/scripts/stores/provenanceStore.js
@@ -101,23 +101,37 @@ export class ProvenanceStore {
     }
 
     @action getWasGeneratedByNode(id, prevGraph) {
-        this.drawerLoading = true;
-        this.transportLayer.getWasGeneratedByNode(id)
-            .then(this.checkResponse)
+        const that = provenanceStore;
+        that.drawerLoading = true;
+        that.transportLayer.getWasGeneratedByNode(id)
+            .then(that.checkResponse)
             .then(response => response.json())
             .then((json) => {
-                this.getProvenanceSuccess(json.graph, prevGraph);
+                if(!json.graph.nodes.length) {
+                    const retryArgs = [id, prevGraph];
+                    const msg = "The provence graph you're requesting is unavailable...";
+                    mainStore.tryAsyncAgain(that.getWasGeneratedByNode, retryArgs, 15000, id, msg, false )
+                } else {
+                    that.getProvenanceSuccess(json.graph, prevGraph);
+                }
             }).catch(ex =>mainStore.handleErrors(ex))
     }
 
     @action getProvenance(id, kind, prevGraph) {
-        this.drawerLoading = true;
-        this.transportLayer.getProvenance(id, kind)
-            .then(this.checkResponse)
+        const that = provenanceStore;
+        that.drawerLoading = true;
+        that.transportLayer.getProvenance(id, kind)
+            .then(that.checkResponse)
             .then(response => response.json())
             .then((json) => {
-                this.getProvenanceSuccess(json.graph, prevGraph);
-            }).catch(ex =>mainStore.handleErrors(ex))
+                if(!json.graph.nodes.length) {
+                    const retryArgs = [id, kind, prevGraph];
+                    const msg = "The provence graph you're requesting is unavailable...";
+                    mainStore.tryAsyncAgain(that.getProvenance, retryArgs, 15000, id, msg, false )
+                } else {
+                    that.getProvenanceSuccess(json.graph, prevGraph);
+                }
+            }).catch(ex => mainStore.handleErrors(ex))
     }
 
     @action getProvenanceSuccess(prov, prevGraph) {


### PR DESCRIPTION
- Retry logic added if provenance graph returns without nodes. `search/provenance/origin` uses neo4j, which, starting recently, was put into background jobs and now works with eventual consistency.
- Adjust icon placement on drawers
