### PR TITLE
allow giving project permissions to users who have the same name

### DIFF
--- a/src/components/projectComponents/projectTeamManager.jsx
+++ b/src/components/projectComponents/projectTeamManager.jsx
@@ -158,8 +158,12 @@ class ProjectTeamManager extends React.Component {
     }
 
     addTeamMember(userName, id) {
-        let chosenUser = this.state.chosenUser;
         let fullName = this.fullName.state.searchText;
+        let chosenUser = null;
+        //only use chosen user if the fullName field still matches what user has typed
+        if (this.state.chosenUser && this.state.chosenUser.fullName == fullName) {
+            chosenUser = this.state.chosenUser;
+        }
         let role;
         switch(this.state.value){
             case 0:

--- a/src/stores/mainStore.js
+++ b/src/stores/mainStore.js
@@ -760,6 +760,20 @@ export class MainStore {
             }).catch(ex => this.handleErrors(ex));
     }
 
+    @action addProjectMemberForUid(uid, id, role) {
+        this.loading = true;
+        this.transportLayer.getUserByUid(uid)
+            .then(this.checkResponse)
+            .then(response => response.json())
+            .then((json) => {
+                let userInfo = json.results.map((result) => {return result.id});
+                let getName = json.results.map((result) => {return result.full_name});
+                let userId = userInfo.toString();
+                let name = getName.toString();
+                this.addProjectMember(id, userId, role, name);
+            }).catch(ex => this.handleErrors(ex));
+    }
+
     @action addProjectTeam(id, userId, role, projectName) {
         this.transportLayer.addProjectMember(id, userId, role)
             .then(this.checkResponse)

--- a/src/transportLayer.js
+++ b/src/transportLayer.js
@@ -195,6 +195,9 @@ const transportLayer = {
     getUserId: (fullName) => {
         return fetch(`${DDS_BASE_URI+apiPrefix}users?full_name_contains=${fullName}&page=1&per_page=500`, getFetchParams('get', authStore.appConfig.apiToken))
     },
+    getUserByUid: (uid) => {
+        return fetch(`${DDS_BASE_URI+apiPrefix}users?username=${uid}&page=1&per_page=500`, getFetchParams('get', authStore.appConfig.apiToken))
+    },
     addProjectMember: (id, userId, role) => {
         const body = {
             'auth_role': {'id': role}


### PR DESCRIPTION
Before this change users that have the same name could not be given project permissions. When adding these users a 404 error was returned. The code that manages project permissions(ProjectTeamManager) only uses the text entered in the AutoComplete box. The change here is a work around to allow adding these users to projects without major changes to the existing code.

Changes here record details about the user chosen via the ProjectTeamManager's autocomplete popup. The autocomplete data includes a users's uid/netid that is unique. This value is then used when adding a user to a project if still valid.

To tell the difference between users who share a name the uid/netid is added after the username in the user selection
autocomplete popup. The uid/netid portion is not retained in the textbox for compatibility with existing code.

See #905